### PR TITLE
v3.4.0: add #[dependencies] macro, rename IronPrint → BuildTimeFinger…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.lock
+/testcrate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toolkit-zero"
-version = "3.3.1"
+version = "3.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Soumyo Deep Gupta <deep.main.ac@gmail.com>"]
@@ -35,15 +35,15 @@ serde       = { version = "1.0.228", optional = true }
 serde_json  = { version = "1", optional = true }
 sha2        = { version = "0.10", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-tokio   = { version = "1.50.0", features = ["rt", "sync", "net"], optional = true }
+tokio   = { version = "1.50.0", features = ["full"], optional = true }
 warp    = { version = "0.4.2", optional = true }
 webbrowser = { version = "0.8", optional = true }
 zeroize = { version = "1", optional = true, features = ["derive"] }
-toolkit-zero-macros = { path = "toolkit-zero-macros", version = "0.2.0", optional = true }
+toolkit-zero-macros = { path = "toolkit-zero-macros", version = "0.3.0", optional = true }
 
 [features]
 default = []
-serialization = ["dep:bincode", "dep:base64"]
+serialization = ["dep:bincode", "dep:base64", "dep:zeroize", "zeroize/derive", "dep:toolkit-zero-macros", "toolkit-zero-macros/serialization"]
 socket = ["socket-server", "socket-client"]
 socket-server = [
     "serialization",
@@ -75,15 +75,15 @@ socket-client = [
     "dep:toolkit-zero-macros",
     "toolkit-zero-macros/socket-client",
 ]
-location = ["location-native"]
-location-native = ["socket-server", "dep:webbrowser", "dep:tokio", "tokio/rt", "tokio/sync", "dep:serde", "dep:rand"]
+location = ["location-browser"]
+location-browser = ["socket-server", "dep:webbrowser", "dep:tokio", "tokio/rt", "tokio/sync", "dep:serde", "dep:rand", "dep:toolkit-zero-macros", "toolkit-zero-macros/location-browser"]
 encryption = ["enc-timelock-keygen-now", "enc-timelock-keygen-input", "enc-timelock-async-keygen-now", "enc-timelock-async-keygen-input"]
-enc-timelock-keygen-now = ["dep:argon2", "dep:scrypt", "dep:zeroize", "dep:chrono", "dep:rand"]
-enc-timelock-keygen-input = ["dep:argon2", "dep:scrypt", "dep:zeroize", "dep:chrono", "dep:rand"]
-enc-timelock-async-keygen-now = ["enc-timelock-keygen-now", "dep:tokio", "tokio/rt"]
-enc-timelock-async-keygen-input = ["enc-timelock-keygen-input", "dep:tokio", "tokio/rt"]
+enc-timelock-keygen-now = ["dep:argon2", "dep:scrypt", "dep:zeroize", "dep:chrono", "dep:rand", "dep:toolkit-zero-macros", "toolkit-zero-macros/enc-timelock-keygen-now"]
+enc-timelock-keygen-input = ["dep:argon2", "dep:scrypt", "dep:zeroize", "dep:chrono", "dep:rand", "dep:toolkit-zero-macros", "toolkit-zero-macros/enc-timelock-keygen-input"]
+enc-timelock-async-keygen-now = ["enc-timelock-keygen-now", "dep:tokio", "tokio/rt", "toolkit-zero-macros/enc-timelock-async-keygen-now"]
+enc-timelock-async-keygen-input = ["enc-timelock-keygen-input", "dep:tokio", "tokio/rt", "toolkit-zero-macros/enc-timelock-async-keygen-input"]
 dependency-graph-build = ["dep:serde_json", "dep:sha2"]
-dependency-graph-capture = ["dep:serde_json"]
+dependency-graph-capture = ["dep:serde_json", "dep:toolkit-zero-macros", "toolkit-zero-macros/dep-graph-capture"]
 backend-deps = []
 
 [[example]]
@@ -95,7 +95,7 @@ name = "veil_seal_open"
 required-features = ["serialization"]
 
 [workspace]
-members = ["toolkit-zero-macros"]
+members = ["testcrate","toolkit-zero-macros"]
 
 [profile.release]
 opt-level       = 3        # maximum optimisation

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A feature-selective Rust utility crate. Declare only the modules your project re
 
 - [Blocking usage](#blocking-usage)
 - [Async usage](#async-usage)
+- [`#[browser]` attribute macro](#browser-attribute-macro)
 - [Page templates](#page-templates)
 - [LocationData fields](#locationdata-fields)
 - [Errors](#locationerror-variants)
@@ -66,12 +67,13 @@ A feature-selective Rust utility crate. Declare only the modules your project re
 </details>
 
 <details>
-<summary>8. <a href="#dependency-graph--ironprint">Dependency Graph — IronPrint</a></summary>
+<summary>8. <a href="#dependency-graph--buildtimefingerprint">Dependency Graph — BuildTimeFingerprint</a></summary>
 
 - [Sections captured](#sections-captured)
 - [Setup](#setup)
-- [Usage](#ironprint-usage)
+- [Usage](#buildtimefingerprint-usage)
 - [Debug export](#debug-export)
+- [`#[dependencies]` attribute macro](#dependencies-attribute-macro)
 - [Risks and considerations](#risks-and-considerations)
 
 </details>
@@ -94,8 +96,8 @@ A feature-selective Rust utility crate. Declare only the modules your project re
 | `socket-server` | Typed HTTP server builder (includes `serialization`) | `toolkit_zero::socket::server` |
 | `socket-client` | Typed HTTP client builder (includes `serialization`) | `toolkit_zero::socket::client` |
 | `socket` | Both `socket-server` and `socket-client` | both socket sub-modules |
-| `location-native` | Browser-based geolocation (includes `socket-server`) | `toolkit_zero::location::browser` |
-| `location` | Alias for `location-native` | `toolkit_zero::location` |
+| `location-browser` | Browser-based geolocation (includes `socket-server`) | `toolkit_zero::location::browser` |
+| `location` | Alias for `location-browser` | `toolkit_zero::location` |
 | `enc-timelock-keygen-now` | Time-lock key derivation from the system clock | `toolkit_zero::encryption::timelock` |
 | `enc-timelock-keygen-input` | Time-lock key derivation from a caller-supplied time | `toolkit_zero::encryption::timelock` |
 | `enc-timelock-async-keygen-now` | Async variant of `enc-timelock-keygen-now` | `toolkit_zero::encryption::timelock` |
@@ -126,10 +128,10 @@ cargo add toolkit-zero --features location
 # Full time-lock encryption suite
 cargo add toolkit-zero --features encryption
 
-# Attach IronPrint fingerprint in build.rs
+# Attach build-time fingerprint in build.rs
 cargo add toolkit-zero --build --features dependency-graph-build
 
-# Read IronPrint fingerprint at runtime
+# Read build-time fingerprint at runtime
 cargo add toolkit-zero --features dependency-graph-capture
 
 # Re-export deps alongside socket-server
@@ -144,14 +146,19 @@ Feature: `serialization`
 
 The VEIL cipher transforms any [`bincode`](https://docs.rs/bincode)-encodable value into an opaque, key-dependent byte sequence. The output carries no recognisable structure; every output byte is a function of the complete input and the key. Without the exact key, the transformation cannot be reversed.
 
+Keys are moved into `seal`/`open` and wrapped in `Zeroizing<String>` internally, wiping them from memory on drop.
+
 **Entry points:**
 
-| Function | Direction |
+| Function / Macro | Direction |
 |---|---|
 | `toolkit_zero::serialization::seal(&value, key)` | struct → `Vec<u8>` |
 | `toolkit_zero::serialization::open::<T>(&bytes, key)` | `Vec<u8>` → struct |
+| `#[serializable]` | derive `Encode+Decode` + inject `.seal()` / `::open()` |
+| `#[serialize(...)]` | inline seal to a variable or file |
+| `#[deserialize(...)]` | inline open from a variable blob or file |
 
-`key` is `Option<&str>`.  Pass `None` to use the built-in default key.
+`key` is `Option<String>`. Pass `None` to use the built-in default key.
 
 **Types must derive `Encode` and `Decode`:**
 
@@ -170,10 +177,53 @@ let blob = seal(&cfg, None).unwrap();
 let back: Config = open(&blob, None).unwrap();
 assert_eq!(cfg, back);
 
-// With a custom shared key
-let blob2 = seal(&cfg, Some("my-secret")).unwrap();
-let back2: Config = open(&blob2, Some("my-secret")).unwrap();
+// With a custom shared key (moved in, zeroized on drop)
+let blob2 = seal(&cfg, Some("my-secret".to_string())).unwrap();
+let back2: Config = open(&blob2, Some("my-secret".to_string())).unwrap();
 assert_eq!(cfg, back2);
+```
+
+**`#[serializable]` — inject methods directly on a struct or enum:**
+
+```rust
+use toolkit_zero::serialization::serializable;
+
+#[serializable]
+struct Config { host: String, port: u16 }
+
+let c = Config { host: "localhost".into(), port: 8080 };
+let blob = c.seal(None).unwrap();
+let back = Config::open(&blob, None).unwrap();
+
+// Per-field encrypted helpers:
+#[serializable]
+struct Creds {
+    pub user: String,
+    #[serializable(key = "field-secret")]
+    pub password: String,
+}
+// → Creds::seal_password(&self), Creds::open_password(bytes)
+```
+
+**`#[serialize]` / `#[deserialize]` — inline seal/open as statements:**
+
+```rust
+use toolkit_zero::serialization::{serialize, deserialize};
+
+// Variable mode
+#[serialize(cfg, key = my_key)]
+fn blob() -> Vec<u8> {}
+// expands to: let blob: Vec<u8> = seal(&cfg, Some(my_key))?;
+
+// File write mode
+#[serialize(cfg, path = "config.bin")]
+fn _() {}
+// expands to: fs::write("config.bin", seal(&cfg, None)?)?;
+
+// Deserialize from file
+#[deserialize(path = "config.bin", key = my_key)]
+fn cfg() -> Config {}
+// expands to: let cfg: Config = open::<Config>(&fs::read("config.bin")?, Some(my_key))?;
 ```
 
 ---
@@ -705,7 +755,7 @@ The return type annotation on the `fn` is **required** — omitting it is a comp
 
 ## Location
 
-Feature: `location` (or `location-native`)
+Feature: `location` (or `location-browser`)
 
 Acquires the device's geographic coordinates by opening a locally served consent page in the system default browser. The browser requests location permission through the standard Web Geolocation API; on approval, the coordinates are submitted to the local HTTP server. The server shuts itself down once a result is received and returns the data to the caller.
 
@@ -742,6 +792,57 @@ async fn main() {
         Ok(data) => println!("lat={:.6}  lon={:.6}", data.latitude, data.longitude),
         Err(e)   => eprintln!("Error: {e}"),
     }
+}
+```
+
+### `#[browser]` attribute macro
+
+The `#[browser]` macro is a concise alternative to calling `__location__` /
+`__location_async__` directly. It replaces the decorated `fn` item with an
+inline location-capture statement. The function **name** becomes the binding;
+the `PageTemplate` is built from the macro arguments. A `?` propagates any
+`LocationError` to the enclosing function.
+
+All arguments are optional and may appear in any order:
+
+| Argument | Type | Notes |
+|---|---|---|
+| `sync` | flag | Use blocking `__location__`; default is `__location_async__().await` |
+| `tickbox` | flag | Use `PageTemplate::Tickbox`; incompatible with `html` |
+| `title = "…"` | string literal | Tab/heading title for Default or Tickbox |
+| `body = "…"` | string literal | Body paragraph text |
+| `consent = "…"` | string literal | Checkbox label (Tickbox only) |
+| `html = "…"` | string literal | `PageTemplate::Custom`; mutually exclusive with all other template args |
+
+```rust
+use toolkit_zero::location::browser::{browser, LocationData, LocationError};
+
+// Async, Default template — all built-in text
+async fn run1() -> Result<LocationData, LocationError> {
+    #[browser]
+    fn loc() {}
+    Ok(loc)
+}
+
+// Async, Tickbox with consent text
+async fn run2() -> Result<LocationData, LocationError> {
+    #[browser(tickbox, title = "Verify Location", consent = "I agree to share my location")]
+    fn loc() {}
+    Ok(loc)
+}
+
+// Async, completely custom HTML page
+async fn run3() -> Result<LocationData, LocationError> {
+    #[browser(html = "<!DOCTYPE html><html><body><h1>Grant access</h1>{}</body></html>")]
+    fn loc() {}
+    Ok(loc)
+}
+
+// Blocking, custom title
+fn run4() -> Result<LocationData, LocationError> {
+    #[browser(sync, title = "My App")]
+    fn loc() {}
+    Ok(loc)
 }
 ```
 
@@ -882,11 +983,11 @@ feature(s).
 
 ---
 
-## Dependency Graph — IronPrint
+## Dependency Graph — BuildTimeFingerprint
 
 Features: `dependency-graph-build` · `dependency-graph-capture`
 
-IronPrint attaches a normalised, deterministic snapshot of the build environment to the compiled binary. The snapshot is written to `$OUT_DIR/ironprint.json` at compile time and embedded via `include_str!`; no runtime I/O is required.
+BuildTimeFingerprint attaches a normalised, deterministic snapshot of the build environment to the compiled binary. The snapshot is written to `$OUT_DIR/fingerprint.json` at compile time and embedded via `include_str!`; no runtime I/O is required.
 
 The two features are intentionally independent so that each can be declared in the appropriate `Cargo.toml` section.
 
@@ -914,23 +1015,23 @@ toolkit-zero = { features = ["dependency-graph-build"] }
 
 ```rust
 fn main() {
-    toolkit_zero::dependency_graph::build::generate_ironprint()
-        .expect("ironprint generation failed");
+    toolkit_zero::dependency_graph::build::generate_fingerprint()
+        .expect("fingerprint generation failed");
     // see "Debug export" below for the optional export() call
 }
 ```
 
-### IronPrint usage
+### BuildTimeFingerprint usage
 
 Embed and read the snapshot in your binary:
 
 ```rust
 use toolkit_zero::dependency_graph::capture;
 
-const IRONPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"));
+const BUILD_TIME_FINGERPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
 
 fn main() {
-    let data = capture::parse(IRONPRINT).expect("failed to parse ironprint");
+    let data = capture::parse(BUILD_TIME_FINGERPRINT).expect("failed to parse fingerprint");
 
     println!("{} v{}", data.package.name, data.package.version);
     println!("profile  : {}", data.build.profile);
@@ -943,12 +1044,12 @@ fn main() {
     }
 
     // raw bytes of the normalised JSON
-    let raw: &[u8] = capture::as_bytes(IRONPRINT);
+    let raw: &[u8] = capture::as_bytes(BUILD_TIME_FINGERPRINT);
     println!("{} bytes", raw.len());
 }
 ```
 
-**`IronprintData` fields:**
+**`BuildTimeFingerprintData` fields:**
 
 | Field | Type | Description |
 |---|---|---|
@@ -965,27 +1066,55 @@ fn main() {
 
 ### Debug export
 
-`export(enabled: bool)` writes a **pretty-printed** `ironprint.json` alongside the crate's `Cargo.toml` for local inspection. This file is distinct from the compact version written to `$OUT_DIR`; the binary always embeds the `$OUT_DIR` copy.
+`export(enabled: bool)` writes a **pretty-printed** `fingerprint.json` alongside the crate's `Cargo.toml` for local inspection. This file is distinct from the compact version written to `$OUT_DIR`; the binary always embeds the `$OUT_DIR` copy.
 
 Pass `cfg!(debug_assertions)` to suppress the file automatically in release builds:
 
 ```rust
 fn main() {
-    toolkit_zero::dependency_graph::build::generate_ironprint()
-        .expect("ironprint generation failed");
+    toolkit_zero::dependency_graph::build::generate_fingerprint()
+        .expect("fingerprint generation failed");
     toolkit_zero::dependency_graph::build::export(cfg!(debug_assertions))
-        .expect("ironprint export failed");
+        .expect("fingerprint export failed");
 }
 ```
 
-> **Add `ironprint.json` to `.gitignore`.**  The exported file contains the full dependency graph, per-file source hashes, target triple, and compiler version. Although the contents are not secret, committing the file adds repository noise and may expose build-environment details beyond what is intended.
+> **Add `fingerprint.json` to `.gitignore`.**  The exported file contains the full dependency graph, per-file source hashes, target triple, and compiler version. Although the contents are not secret, committing the file adds repository noise and may expose build-environment details beyond what is intended.
+
+### `#[dependencies]` attribute macro
+
+The `#[dependencies]` macro is a concise alternative to the `include_str!` + `capture::parse()` boilerplate. It requires the `dependency-graph-capture` feature.
+
+Apply it to an empty `fn` inside a function body; the function name becomes the `let` binding:
+
+```rust
+use toolkit_zero::dependency_graph::capture::dependencies;
+
+fn show() -> Result<(), Box<dyn std::error::Error>> {
+    #[dependencies]          // → let data: BuildTimeFingerprintData = parse(...)?;
+    fn data() {}
+    println!("{} v{}", data.package.name, data.package.version);
+    Ok(())
+}
+
+fn raw_bytes() -> &'static [u8] {
+    #[dependencies(bytes)]   // → let raw: &'static [u8] = as_bytes(...);
+    fn raw() {}
+    raw
+}
+```
+
+| Form | Result type | Propagates `?` |
+|---|---|---|
+| `#[dependencies]` | `BuildTimeFingerprintData` | yes |
+| `#[dependencies(bytes)]` | `&'static [u8]` | no |
 
 ### Risks and considerations
 
 | Concern | Detail |
 |---|---|
 | **Not tamper-proof** | The fingerprint is embedded as plain text in the binary's read-only data section. Anyone with access to the binary can read it. It is informational, not a security boundary. |
-| **Export file exposure** | `export(true)` writes `ironprint.json` to the crate root. Add it to `.gitignore` to prevent accidental commits. |
+| **Export file exposure** | `export(true)` writes `fingerprint.json` to the crate root. Add it to `.gitignore` to prevent accidental commits. |
 | **Build-time overhead** | `cargo metadata` runs on every rebuild. The `cargo:rerun-if-changed` directives restrict this to changes in `src/`, `Cargo.toml`, or `Cargo.lock` — unchanged builds do not re-run. |
 | **Feature capture scope** | `build.features` captures the active features of the crate being built, not toolkit-zero's own features. |
 | **Absolute-path stripping** | `workspace_root`, `manifest_path`, `src_path`, `path`, and other machine-specific fields are removed from `cargo metadata` output. The fingerprint is stable across different machines and checkout locations. |
@@ -1001,7 +1130,7 @@ When combined with any other feature, `backend-deps` appends a `backend_deps` su
 
 | Module | Path | Re-exports |
 |---|---|---|
-| `serialization` | `toolkit_zero::serialization::backend_deps` | `bincode`, `base64` |
+| `serialization` | `toolkit_zero::serialization::backend_deps` | `bincode`, `base64`, `zeroize` |
 | `socket` (server side) | `toolkit_zero::socket::backend_deps` | `bincode`, `base64`, `serde`, `tokio`, `log`, `bytes`, `serde_urlencoded`, `warp` |
 | `socket` (client side) | `toolkit_zero::socket::backend_deps` | `bincode`, `base64`, `serde`, `tokio`, `log`, `reqwest` |
 | `location` | `toolkit_zero::location::backend_deps` | `tokio`, `serde`, `webbrowser`, `rand` |

--- a/examples/veil_seal_open.rs
+++ b/examples/veil_seal_open.rs
@@ -35,19 +35,19 @@ fn main() {
 
     // ── Seal ──────────────────────────────────────────────────────────────────
     // Transforms Payload into an opaque byte blob.
-    let blob = seal(&original, Some(key)).expect("seal failed");
+    let blob = seal(&original, Some(key.to_string())).expect("seal failed");
     println!("Sealed   : {} bytes  (opaque — no structure visible)", blob.len());
 
     // ── Open ──────────────────────────────────────────────────────────────────
     // Reconstructs Payload from the opaque blob using the same key.
-    let recovered: Payload = open(&blob, Some(key)).expect("open failed");
+    let recovered: Payload = open(&blob, Some(key.to_string())).expect("open failed");
     println!("Recovered: {recovered:?}");
 
     assert_eq!(original, recovered, "round-trip mismatch!");
     println!("\nRound-trip successful ✓");
 
     // ── Wrong key rejects ─────────────────────────────────────────────────────
-    let bad: Result<Payload, _> = open(&blob, Some("wrong-key"));
+    let bad: Result<Payload, _> = open(&blob, Some("wrong-key".to_string()));
     assert!(bad.is_err(), "wrong key should fail to open");
     println!("Wrong-key rejection ✓");
 }

--- a/src/dependency-graph/build.rs
+++ b/src/dependency-graph/build.rs
@@ -1,6 +1,6 @@
 //! Build-time fingerprint generator for use in a downstream `build.rs`.
 //!
-//! Produces **`ironprint.json`** in `$OUT_DIR`: a compact, normalised,
+//! Produces **`fingerprint.json`** in `$OUT_DIR`: a compact, normalised,
 //! deterministically sorted JSON document capturing a stable snapshot of the
 //! build environment.
 //!
@@ -8,8 +8,8 @@
 //!
 //! | Function | Description |
 //! |---|---|
-//! | [`generate_ironprint`] | Always call this. Writes compact `ironprint.json` to `$OUT_DIR` and emits `cargo:rerun-if-changed` directives. |
-//! | [`export`] | Optional. Writes a pretty-printed `ironprint.json` alongside `Cargo.toml` for local inspection. Pass `false` or condition on `cfg!(debug_assertions)` to suppress in release builds. |
+//! | [`generate_fingerprint`] | Always call this. Writes compact `fingerprint.json` to `$OUT_DIR` and emits `cargo:rerun-if-changed` directives. |
+//! | [`export`] | Optional. Writes a pretty-printed `fingerprint.json` alongside `Cargo.toml` for local inspection. Pass `false` or condition on `cfg!(debug_assertions)` to suppress in release builds. |
 //!
 //! ## Sections captured
 //!
@@ -27,18 +27,18 @@
 //!
 //! ```rust,ignore
 //! fn main() {
-//!     toolkit_zero::dependency_graph::build::generate_ironprint()
-//!         .expect("ironprint generation failed");
+//!     toolkit_zero::dependency_graph::build::generate_fingerprint()
+//!         .expect("fingerprint generation failed");
 //!     // optional — pretty-print alongside Cargo.toml for local inspection
 //!     toolkit_zero::dependency_graph::build::export(cfg!(debug_assertions))
-//!         .expect("ironprint export failed");
+//!         .expect("fingerprint export failed");
 //! }
 //! ```
 //!
 //! Embed the fingerprint in the binary:
 //!
 //! ```rust,ignore
-//! const IRONPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"));
+//! const BUILD_TIME_FINGERPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
 //! ```
 //!
 //! ## Concerns
@@ -46,7 +46,7 @@
 //! * **Not tamper-proof** — the fingerprint resides as plain text in the binary's
 //!   read-only data section. It is informational in nature; it does not constitute
 //!   a security boundary.
-//! * **Export file** — `export(true)` writes `ironprint.json` to the crate root.
+//! * **Export file** — `export(true)` writes `fingerprint.json` to the crate root.
 //!   Add it to `.gitignore` to prevent unintentional commits.
 //! * **Build-time overhead** — `cargo metadata` is executed on every rebuild.
 //!   The `cargo:rerun-if-changed` directives restrict this to changes in `src/`,
@@ -65,9 +65,9 @@ use sha2::{Digest, Sha256};
 
 // ─── public error ────────────────────────────────────────────────────────────
 
-/// Errors that can occur while generating `ironprint.json`.
+/// Errors that can occur while generating `fingerprint.json`.
 #[derive(Debug)]
-pub enum IronprintError {
+pub enum BuildTimeFingerprintError {
     /// `cargo metadata` process failed or returned non-zero.
     CargoMetadataFailed(String),
     /// `cargo metadata` stdout was not valid UTF-8.
@@ -82,7 +82,7 @@ pub enum IronprintError {
     SerializationFailed(String),
 }
 
-impl std::fmt::Display for IronprintError {
+impl std::fmt::Display for BuildTimeFingerprintError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::CargoMetadataFailed(e)      => write!(f, "cargo metadata failed: {e}"),
@@ -95,15 +95,15 @@ impl std::fmt::Display for IronprintError {
     }
 }
 
-impl std::error::Error for IronprintError {}
+impl std::error::Error for BuildTimeFingerprintError {}
 
-impl From<std::io::Error> for IronprintError {
+impl From<std::io::Error> for BuildTimeFingerprintError {
     fn from(e: std::io::Error) -> Self { Self::IoError(e) }
 }
 
 // ─── public entry point ──────────────────────────────────────────────────────
 
-/// Generate `ironprint.json` in `$OUT_DIR`.
+/// Generate `fingerprint.json` in `$OUT_DIR`.
 ///
 /// All inputs are read from the environment variables that Cargo sets for
 /// `build.rs` scripts. The necessary `cargo:rerun-if-changed` directives are
@@ -115,11 +115,11 @@ impl From<std::io::Error> for IronprintError {
 ///
 /// ```rust,ignore
 /// fn main() {
-///     toolkit_zero::dependency_graph::build::generate_ironprint()
-///         .expect("ironprint generation failed");
+///     toolkit_zero::dependency_graph::build::generate_fingerprint()
+///         .expect("fingerprint generation failed");
 /// }
 /// ```
-pub fn generate_ironprint() -> Result<(), IronprintError> {
+pub fn generate_fingerprint() -> Result<(), BuildTimeFingerprintError> {
     // Emit rerun directives — cargo reads these from build script stdout
     // regardless of which function in the call stack prints them.
     println!("cargo:rerun-if-changed=src");
@@ -130,52 +130,52 @@ pub fn generate_ironprint() -> Result<(), IronprintError> {
 
     let fingerprint = build_fingerprint()?;
     let compact = serde_json::to_string(&fingerprint)
-        .map_err(|e| IronprintError::SerializationFailed(e.to_string()))?;
+        .map_err(|e| BuildTimeFingerprintError::SerializationFailed(e.to_string()))?;
 
-    fs::write(format!("{out_dir}/ironprint.json"), compact)?;
+    fs::write(format!("{out_dir}/fingerprint.json"), compact)?;
     Ok(())
 }
 
-/// Write a pretty-printed `ironprint.json` alongside the crate's `Cargo.toml`
+/// Write a pretty-printed `fingerprint.json` alongside the crate's `Cargo.toml`
 /// when `enabled` is `true`.
 ///
 /// This file is intended for **local inspection only**. It is distinct from
-/// the compact `ironprint.json` written to `$OUT_DIR`; the binary always
+/// the compact `fingerprint.json` written to `$OUT_DIR`; the binary always
 /// embeds the `$OUT_DIR` copy. Pass `false`, or condition the call on
 /// `cfg!(debug_assertions)`, to suppress the file in release builds.
 ///
 /// # Concerns
 ///
 /// The exported file contains the full dependency graph, per-file source
-/// hashes, target triple, and compiler version. **Add `ironprint.json` to
+/// hashes, target triple, and compiler version. **Add `fingerprint.json` to
 /// `.gitignore`** to prevent unintentional commits. If an error occurs and
 /// `enabled` is `true`, the file may be partially written; the error is
 /// propagated to the caller.
 ///
 /// ```rust,ignore
 /// fn main() {
-///     toolkit_zero::dependency_graph::build::generate_ironprint()
-///         .expect("ironprint generation failed");
+///     toolkit_zero::dependency_graph::build::generate_fingerprint()
+///         .expect("fingerprint generation failed");
 ///     toolkit_zero::dependency_graph::build::export(cfg!(debug_assertions))
-///         .expect("ironprint export failed");
+///         .expect("fingerprint export failed");
 /// }
 /// ```
-pub fn export(enabled: bool) -> Result<(), IronprintError> {
+pub fn export(enabled: bool) -> Result<(), BuildTimeFingerprintError> {
     if !enabled { return Ok(()); }
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
 
     let fingerprint = build_fingerprint()?;
     let pretty = serde_json::to_string_pretty(&fingerprint)
-        .map_err(|e| IronprintError::SerializationFailed(e.to_string()))?;
+        .map_err(|e| BuildTimeFingerprintError::SerializationFailed(e.to_string()))?;
 
-    fs::write(format!("{manifest_dir}/ironprint.json"), pretty)?;
+    fs::write(format!("{manifest_dir}/fingerprint.json"), pretty)?;
     Ok(())
 }
 
-// ─── core fingerprint builder (shared by generate_ironprint + export) ─────────
+// ─── core fingerprint builder (shared by generate_fingerprint + export) ────────
 
-fn build_fingerprint() -> Result<Value, IronprintError> {
+fn build_fingerprint() -> Result<Value, BuildTimeFingerprintError> {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
 
     // ── 1. Package identity ───────────────────────────────────────────────────
@@ -216,18 +216,18 @@ fn build_fingerprint() -> Result<Value, IronprintError> {
             &format!("{manifest_dir}/Cargo.toml"),
         ])
         .output()
-        .map_err(|e| IronprintError::CargoMetadataFailed(e.to_string()))?;
+        .map_err(|e| BuildTimeFingerprintError::CargoMetadataFailed(e.to_string()))?;
 
     if !meta_out.status.success() {
         let err = String::from_utf8_lossy(&meta_out.stderr).to_string();
-        return Err(IronprintError::CargoMetadataFailed(err));
+        return Err(BuildTimeFingerprintError::CargoMetadataFailed(err));
     }
 
     let meta_str = String::from_utf8(meta_out.stdout)
-        .map_err(|_| IronprintError::CargoMetadataNotUtf8)?;
+        .map_err(|_| BuildTimeFingerprintError::CargoMetadataNotUtf8)?;
 
     let meta_raw: Value = serde_json::from_str(&meta_str)
-        .map_err(|e| IronprintError::CargoMetadataInvalidJson(e.to_string()))?;
+        .map_err(|e| BuildTimeFingerprintError::CargoMetadataInvalidJson(e.to_string()))?;
 
     let meta_clean      = strip_absolute_paths(meta_raw);
     let meta_normalised = normalise_json(meta_clean);
@@ -235,7 +235,7 @@ fn build_fingerprint() -> Result<Value, IronprintError> {
     // ── 5. Cargo.lock SHA-256 ─────────────────────────────────────────────────
     let lock_path = format!("{manifest_dir}/Cargo.lock");
     if !Path::new(&lock_path).exists() {
-        return Err(IronprintError::CargoLockNotFound(lock_path));
+        return Err(BuildTimeFingerprintError::CargoLockNotFound(lock_path));
     }
     let lock_raw = fs::read(&lock_path)?;
     let lock_stripped: Vec<u8> = lock_raw
@@ -373,7 +373,7 @@ fn hex_sha256(data: &[u8]) -> String {
 fn hash_source_tree(
     src_dir:      &str,
     manifest_dir: &str,
-) -> Result<BTreeMap<String, String>, IronprintError> {
+) -> Result<BTreeMap<String, String>, BuildTimeFingerprintError> {
     let mut map = BTreeMap::new();
     visit_rs_files(Path::new(src_dir), Path::new(manifest_dir), &mut map)?;
     Ok(map)
@@ -383,7 +383,7 @@ fn visit_rs_files(
     dir:  &Path,
     base: &Path,
     map:  &mut BTreeMap<String, String>,
-) -> Result<(), IronprintError> {
+) -> Result<(), BuildTimeFingerprintError> {
     if !dir.exists() {
         return Ok(());
     }

--- a/src/dependency-graph/capture.rs
+++ b/src/dependency-graph/capture.rs
@@ -1,16 +1,16 @@
-//! Runtime reader for the `ironprint.json` fingerprint embedded in the binary.
+//! Runtime reader for the `fingerprint.json` embedded in the binary.
 //!
 //! The companion `build` module (feature `dependency-graph-build`) writes
-//! `ironprint.json` to `$OUT_DIR` at compile time. The downstream binary
+//! `fingerprint.json` to `$OUT_DIR` at compile time. The downstream binary
 //! embeds it with:
 //!
 //! ```rust,ignore
-//! const IRONPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"));
+//! const BUILD_TIME_FINGERPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
 //! ```
 //!
 //! ## Functions
 //!
-//! * [`parse`] — deserialises the embedded JSON into a typed [`IronprintData`]
+//! * [`parse`] — deserialises the embedded JSON into a typed [`BuildTimeFingerprintData`]
 //!   struct. Returns [`CaptureError`] if the JSON is malformed or a required
 //!   section is absent.
 //! * [`as_bytes`] — returns the raw JSON bytes. Because the JSON is normalised
@@ -31,7 +31,7 @@ use serde_json::Value;
 
 // ─── error ────────────────────────────────────────────────────────────────────
 
-/// Errors that can occur while reading a captured ironprint.
+/// Errors that can occur while reading a captured fingerprint.
 #[derive(Debug)]
 pub enum CaptureError {
     /// The embedded JSON is not valid.
@@ -43,8 +43,8 @@ pub enum CaptureError {
 impl std::fmt::Display for CaptureError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidJson(e)      => write!(f, "ironprint JSON is invalid: {e}"),
-            Self::MissingSection(key) => write!(f, "ironprint is missing section: {key}"),
+            Self::InvalidJson(e)      => write!(f, "fingerprint JSON is invalid: {e}"),
+            Self::MissingSection(key) => write!(f, "fingerprint is missing section: {key}"),
         }
     }
 }
@@ -53,12 +53,12 @@ impl std::error::Error for CaptureError {}
 
 // ─── typed data ───────────────────────────────────────────────────────────────
 
-/// Parsed contents of `ironprint.json`.
+/// Parsed contents of `fingerprint.json`.
 ///
 /// All fields map directly onto the sections produced by
-/// [`build::generate_ironprint`](super::build::generate_ironprint).
+/// [`build::generate_fingerprint`](super::build::generate_fingerprint).
 #[derive(Debug, Clone)]
-pub struct IronprintData {
+pub struct BuildTimeFingerprintData {
     /// Package name and version.
     pub package: PackageInfo,
     /// Build-environment snapshot.
@@ -95,11 +95,11 @@ pub struct BuildInfo {
 
 // ─── public API ───────────────────────────────────────────────────────────────
 
-/// Parse the embedded ironprint JSON into a typed [`IronprintData`].
+/// Parse the embedded fingerprint JSON into a typed [`BuildTimeFingerprintData`].
 ///
 /// Pass the `&str` produced by
-/// `include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"))`.
-pub fn parse(json: &str) -> Result<IronprintData, CaptureError> {
+/// `include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"))`.
+pub fn parse(json: &str) -> Result<BuildTimeFingerprintData, CaptureError> {
     let root: Value = serde_json::from_str(json)
         .map_err(|e| CaptureError::InvalidJson(e.to_string()))?;
 
@@ -160,20 +160,36 @@ pub fn parse(json: &str) -> Result<IronprintData, CaptureError> {
         })
         .unwrap_or_default();
 
-    Ok(IronprintData { package, build, cargo_lock_sha256, deps, source })
+    Ok(BuildTimeFingerprintData { package, build, cargo_lock_sha256, deps, source })
 }
 
-/// Return the raw bytes of the ironprint JSON string.
+/// Return the raw bytes of the fingerprint JSON string.
 ///
-/// Because `ironprint.json` is already normalised (sorted keys, no whitespace,
+/// Because `fingerprint.json` is already normalised (sorted keys, no whitespace,
 /// no absolute paths) at build time, the returned bytes are stable and
 /// deterministic across equivalent builds.
 ///
 /// ```rust,ignore
-/// const IRONPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"));
+/// const BUILD_TIME_FINGERPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
 ///
-/// let bytes: &[u8] = toolkit_zero::dependency_graph::capture::as_bytes(IRONPRINT);
+/// let bytes: &[u8] = toolkit_zero::dependency_graph::capture::as_bytes(BUILD_TIME_FINGERPRINT);
 /// ```
 pub fn as_bytes(json: &str) -> &[u8] {
     json.as_bytes()
 }
+
+// ─── attribute macro ──────────────────────────────────────────────────────────
+
+/// Embed and bind the build-time `fingerprint.json` in one expression.
+///
+/// Apply to an empty `fn` inside a function body; the function name becomes
+/// the `let` binding in the expansion.
+///
+/// ```text
+/// #[dependencies]          // parse mode  → BuildTimeFingerprintData (propagates ?)
+/// #[dependencies(bytes)]   // bytes mode  → &'static [u8]
+/// ```
+///
+/// Requires the `dependency-graph-capture` feature.
+#[cfg(feature = "dependency-graph-capture")]
+pub use toolkit_zero_macros::dependencies;

--- a/src/dependency-graph/mod.rs
+++ b/src/dependency-graph/mod.rs
@@ -1,11 +1,11 @@
-//! Build-time dependency-graph fingerprinting (**IronPrint**).
+//! Build-time dependency-graph fingerprinting (**BuildTimeFingerprint**).
 //!
 //! Two mutually independent feature gates control the facility:
 //!
 //! | Feature | Provided symbols |
 //! |---|---|
-//! | `dependency-graph-build` | [`build::generate_ironprint`] — writes a compact, normalised `ironprint.json` to `$OUT_DIR`;<br>[`build::export`] — optionally writes a pretty-printed copy alongside `Cargo.toml` |
-//! | `dependency-graph-capture` | [`capture::parse`] — deserialises the embedded snapshot into a typed [`capture::IronprintData`];<br>[`capture::as_bytes`] — returns the raw, deterministic JSON bytes |
+//! | `dependency-graph-build` | [`build::generate_fingerprint`] — writes a compact, normalised `fingerprint.json` to `$OUT_DIR`;<br>[`build::export`] — optionally writes a pretty-printed copy alongside `Cargo.toml` |
+//! | `dependency-graph-capture` | [`capture::parse`] — deserialises the embedded snapshot into a typed [`capture::BuildTimeFingerprintData`];<br>[`capture::as_bytes`] — returns the raw, deterministic JSON bytes |
 //!
 //! Place `dependency-graph-build` in `[build-dependencies]` and
 //! `dependency-graph-capture` in `[dependencies]`; neither implies the other.
@@ -15,7 +15,7 @@
 //! * The fingerprint is stored as **plain text** in the binary's read-only data
 //!   section. It is informational in nature; it does not constitute a security
 //!   boundary and is not tamper-evident.
-//! * Calling `export(true)` writes `ironprint.json` to the crate root. Add this
+//! * Calling `export(true)` writes `fingerprint.json` to the crate root. Add this
 //!   file to `.gitignore` to prevent unintentional exposure of build-environment
 //!   details.
 //! * The snapshot is fixed at compile time and does not reflect runtime state.

--- a/src/encryption/timelock/mod.rs
+++ b/src/encryption/timelock/mod.rs
@@ -1619,3 +1619,40 @@ mod tests {
         );
     }
 }
+
+// ─── attribute macro re-export ────────────────────────────────────────────────
+
+/// Concise attribute macro for deriving a time-locked key inline.
+///
+/// Replaces the decorated `fn` with a call to [`timelock`] (sync) or
+/// [`timelock_async`] (async, add the `async` flag). See
+/// [`toolkit_zero_macros::timelock`] for the full argument reference.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use toolkit_zero::encryption::timelock::*;
+///
+/// // Encryption — derive for 14:37 with Minute precision.
+/// fn encrypt_key() -> Result<TimeLockKey, TimeLockError> {
+///     let salts = TimeLockSalts::generate();
+///     let kdf   = KdfPreset::Balanced.params();
+///     #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = salts, kdf = kdf)]
+///     fn key() {}
+///     Ok(key)
+/// }
+///
+/// // Decryption — re-derive from a stored header.
+/// fn decrypt_key(header: TimeLockParams) -> Result<TimeLockKey, TimeLockError> {
+///     #[timelock(params = header)]
+///     fn key() {}
+///     Ok(key)
+/// }
+/// ```
+#[cfg(any(
+    feature = "enc-timelock-keygen-now",
+    feature = "enc-timelock-keygen-input",
+    feature = "enc-timelock-async-keygen-now",
+    feature = "enc-timelock-async-keygen-input",
+))]
+pub use toolkit_zero_macros::timelock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! 4. [Socket — client](#socket--client)
 //! 5. [Location](#location)
 //! 6. [Encryption — Timelock](#encryption--timelock)
-//! 7. [Dependency Graph — IronPrint](#dependency-graph--ironprint)
+//! 7. [Dependency Graph — BuildTimeFingerprint](#dependency-graph--buildtimefingerprint)
 //! 8. [Backend deps](#backend-deps-1)
 //!
 //! ---
@@ -22,20 +22,20 @@
 //! ## Feature flags
 //!
 //! | Feature | Enables | Exposes |
-//! |---|---||---|
+//! |---|---|---|
 //! | `serialization` | VEIL cipher (seal / open) | [`serialization`] |
 //! | `socket-server` | VEIL + typed HTTP server builder | [`socket::server`] |
 //! | `socket-client` | VEIL + typed HTTP client builder | [`socket::client`] |
 //! | `socket` | Both `socket-server` and `socket-client` | both |
-//! | `location-native` | Browser-based geolocation | [`location::browser`] |
-//! | `location` | Alias for `location-native` | [`location`] |
+//! | `location-browser` | Browser-based geolocation | [`location::browser`] |
+//! | `location` | Alias for `location-browser` | [`location`] |
 //! | `enc-timelock-keygen-now` | Time-lock key derivation from the system clock | [`encryption::timelock::derive_key_now`] |
 //! | `enc-timelock-keygen-input` | Time-lock key derivation from a caller-supplied time | [`encryption::timelock::derive_key_at`] |
 //! | `enc-timelock-async-keygen-now` | Async variant of `enc-timelock-keygen-now` | [`encryption::timelock::derive_key_now_async`] |
 //! | `enc-timelock-async-keygen-input` | Async variant of `enc-timelock-keygen-input` | [`encryption::timelock::derive_key_at_async`] |
 //! | `encryption` | All four `enc-timelock-*` features | [`encryption::timelock`] |
-//! | `dependency-graph-build` | Attach a normalised dependency-graph snapshot (`ironprint.json`) at build time | [`dependency_graph::build`] |
-//! | `dependency-graph-capture` | Read the embedded `ironprint.json` snapshot at runtime | [`dependency_graph::capture`] |
+//! | `dependency-graph-build` | Attach a normalised dependency-graph snapshot (`fingerprint.json`) at build time | [`dependency_graph::build`] |
+//! | `dependency-graph-capture` | Read the embedded `fingerprint.json` snapshot at runtime | [`dependency_graph::capture`] |
 //! | `backend-deps` | Re-exports all third-party deps used by each active module | `*::backend_deps` |
 //!
 //! ```toml
@@ -58,11 +58,11 @@
 //! # Full time-lock encryption suite
 //! toolkit-zero = { version = "3", features = ["encryption"] }
 //!
-//! # Attach IronPrint fingerprint in build.rs
+//! # Attach build-time fingerprint in build.rs
 //! # [build-dependencies]
 //! toolkit-zero = { version = "3", features = ["dependency-graph-build"] }
 //!
-//! # Read IronPrint fingerprint at runtime
+//! # Read build-time fingerprint at runtime
 //! # [dependencies]
 //! toolkit-zero = { version = "3", features = ["dependency-graph-capture"] }
 //!
@@ -78,9 +78,20 @@
 //! key-dependent binary codec that transforms any [`bincode`]-encodable value
 //! into an opaque byte sequence and back.
 //!
+//! Keys are moved into [`serialization::seal`] / [`serialization::open`] and
+//! wrapped in `Zeroizing<String>` internally, wiping them from memory on drop.
+//!
 //! The two entry points are [`serialization::seal`] and [`serialization::open`].
 //! Every output byte is a function of the complete input and the key; without
 //! the exact key, the output cannot be reversed.
+//!
+//! Three attribute macros are also available via the `serialization` feature:
+//!
+//! | Macro | Purpose |
+//! |---|---|
+//! | [`serialization::serializable`] | derive `Encode+Decode` + inject `seal`/`open` methods |
+//! | [`serialization::serialize`] | inline seal to a variable or a file |
+//! | [`serialization::deserialize`] | inline open from a variable blob or a file |
 //!
 //! ```rust,ignore
 //! use toolkit_zero::serialization::{seal, open, Encode, Decode};
@@ -93,8 +104,8 @@
 //! let back: Point = open(&blob, None).unwrap();
 //! assert_eq!(p, back);
 //!
-//! let blob2 = seal(&p, Some("my-key")).unwrap();              // custom key
-//! let back2: Point = open(&blob2, Some("my-key")).unwrap();
+//! let blob2 = seal(&p, Some("my-key".to_string())).unwrap();              // custom key
+//! let back2: Point = open(&blob2, Some("my-key".to_string())).unwrap();
 //! assert_eq!(p, back2);
 //! ```
 //!
@@ -309,7 +320,7 @@
 //!
 //! ## Location
 //!
-//! The `location` (or `location-native`) feature provides browser-based geographic
+//! The `location` (or `location-browser`) feature provides browser-based geographic
 //! coordinate acquisition. A temporary HTTP server is bound on a randomly assigned
 //! local port, the system default browser is directed to a consent page, and the
 //! coordinates are submitted via the standard Web Geolocation API. The server
@@ -345,6 +356,42 @@
 //! a plain single-button page, a checkbox-gated variant, or a fully custom HTML
 //! document.
 //!
+//! ### `#[browser]` attribute macro
+//!
+//! The [`location::browser::browser`] attribute macro is a concise alternative
+//! to calling `__location__` / `__location_async__` directly. It replaces the
+//! decorated `fn` item with an inline location-capture statement; the function
+//! **name** becomes the binding that holds the resulting
+//! [`location::browser::LocationData`], and the [`location::browser::PageTemplate`]
+//! is built from the macro arguments.
+//!
+//! ```rust,ignore
+//! use toolkit_zero::location::browser::{browser, LocationData, LocationError};
+//!
+//! async fn get_location() -> Result<LocationData, LocationError> {
+//!     // async, plain Default template
+//!     #[browser]
+//!     fn loc() {}
+//!     Ok(loc)
+//! }
+//!
+//! async fn get_location_tickbox() -> Result<LocationData, LocationError> {
+//!     // async, Tickbox with consent text
+//!     #[browser(tickbox, title = "Verify Location", consent = "I agree")]
+//!     fn loc() {}
+//!     Ok(loc)
+//! }
+//!
+//! fn get_location_sync() -> Result<LocationData, LocationError> {
+//!     // blocking, custom title
+//!     #[browser(sync, title = "My App")]
+//!     fn loc() {}
+//!     Ok(loc)
+//! }
+//! ```
+//!
+//! See [`location::browser::browser`] for the full argument reference.
+//!
 //! ---
 //!
 //! ## Encryption — Timelock
@@ -373,7 +420,7 @@
 //! tuned per platform: `Balanced`, `Paranoid`, `BalancedMac`, `ParanoidMac`,
 //! `BalancedX86`, `ParanoidX86`, `BalancedArm`, `ParanoidArm`, and `Custom(KdfParams)`.
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use toolkit_zero::encryption::timelock::*;
 //!
 //! // Encryption side — caller sets the unlock time
@@ -407,26 +454,51 @@
 //!
 //! ---
 //!
-//! ## Dependency Graph — IronPrint
+//! ## Dependency Graph — BuildTimeFingerprint
 //!
 //! Two features; one for each side of the boundary.
 //!
 //! **`dependency-graph-build`** (goes in `[build-dependencies]`):
-//! [`dependency_graph::build::generate_ironprint`] runs `cargo metadata`, hashes
+//! [`dependency_graph::build::generate_fingerprint`] runs `cargo metadata`, hashes
 //! `Cargo.lock` and every `.rs` file under `src/`, captures the profile, target
 //! triple, rustc version, and active features, then writes a compact, normalised
-//! JSON document to `$OUT_DIR/ironprint.json`.
+//! JSON document to `$OUT_DIR/fingerprint.json`.
 //! [`dependency_graph::build::export`] optionally writes a pretty-printed copy
 //! alongside `Cargo.toml` for local inspection — pass `false` or
 //! `cfg!(debug_assertions)` to suppress it in release builds.
 //!
 //! **`dependency-graph-capture`** (goes in `[dependencies]`):
 //! [`dependency_graph::capture::parse`] deserialises the embedded snapshot into a
-//! typed [`dependency_graph::capture::IronprintData`] struct.
+//! typed [`dependency_graph::capture::BuildTimeFingerprintData`] struct.
 //! [`dependency_graph::capture::as_bytes`] returns the raw JSON bytes, which are
 //! stable and deterministic across equivalent builds.
 //!
-//! ### Sections captured in `ironprint.json`
+//! ### `#[dependencies]` attribute macro
+//!
+//! The [`dependency_graph::capture::dependencies`] attribute macro is a concise
+//! alternative to the manual `include_str!` + `parse()` boilerplate. Apply it to
+//! an empty `fn`; the function name becomes the binding.
+//!
+//! ```rust,ignore
+//! use toolkit_zero::dependency_graph::capture::dependencies;
+//!
+//! fn show() -> Result<(), Box<dyn std::error::Error>> {
+//!     #[dependencies]             // → let data: BuildTimeFingerprintData = parse(...)?;
+//!     fn data() {}
+//!     println!("{} v{}", data.package.name, data.package.version);
+//!     Ok(())
+//! }
+//!
+//! fn raw() -> &'static [u8] {
+//!     #[dependencies(bytes)]      // → let raw: &'static [u8] = as_bytes(...);
+//!     fn raw() {}
+//!     raw
+//! }
+//! ```
+//!
+//! See [`dependency_graph::capture::dependencies`] for the full syntax reference.
+//!
+//! ### Sections captured in `fingerprint.json`
 //!
 //! | Section | Contents |
 //! |---|---|
@@ -450,11 +522,11 @@
 //!
 //! ```rust,ignore
 //! fn main() {
-//!     toolkit_zero::dependency_graph::build::generate_ironprint()
-//!         .expect("ironprint generation failed");
+//!     toolkit_zero::dependency_graph::build::generate_fingerprint()
+//!         .expect("fingerprint generation failed");
 //!     // optional: pretty-print to crate root for local inspection
 //!     toolkit_zero::dependency_graph::build::export(cfg!(debug_assertions))
-//!         .expect("ironprint export failed");
+//!         .expect("fingerprint export failed");
 //! }
 //! ```
 //!
@@ -463,15 +535,15 @@
 //! ```rust,ignore
 //! use toolkit_zero::dependency_graph::capture;
 //!
-//! const IRONPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/ironprint.json"));
+//! const BUILD_TIME_FINGERPRINT: &str = include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
 //!
 //! fn main() {
-//!     let data = capture::parse(IRONPRINT).expect("failed to parse ironprint");
+//!     let data = capture::parse(BUILD_TIME_FINGERPRINT).expect("failed to parse fingerprint");
 //!     println!("{} v{}", data.package.name, data.package.version);
 //!     println!("target : {}", data.build.target);
 //!     println!("lock   : {}", data.cargo_lock_sha256);
 //!
-//!     let raw = capture::as_bytes(IRONPRINT);
+//!     let raw = capture::as_bytes(BUILD_TIME_FINGERPRINT);
 //!     println!("{} bytes", raw.len());
 //! }
 //! ```
@@ -482,7 +554,7 @@
 //!   binary's read-only data section and is readable by anyone with access to
 //!   the binary. It is informational in nature; it does not constitute a
 //!   security boundary.
-//! * **Export file** — `export(true)` writes `ironprint.json` to the crate root.
+//! * **Export file** — `export(true)` writes `fingerprint.json` to the crate root.
 //!   Add it to `.gitignore` to prevent accidental commits.
 //! * **Build-time overhead** — `cargo metadata` runs on every rebuild triggered
 //!   by the `cargo:rerun-if-changed` directives (changes to `src/`, `Cargo.toml`,
@@ -505,7 +577,7 @@
 //!
 //! | Module | Path | Re-exports |
 //! |---|---|---|
-//! | serialization | [`serialization::backend_deps`] | `bincode`, `base64` |
+//! | serialization | [`serialization::backend_deps`] | `bincode`, `base64`, `zeroize` |
 //! | socket (server) | [`socket::backend_deps`] | `bincode`, `base64`, `serde`, `tokio`, `log`, `bytes`, `serde_urlencoded`, `warp` |
 //! | socket (client) | [`socket::backend_deps`] | `bincode`, `base64`, `serde`, `tokio`, `log`, `reqwest` |
 //! | location | [`location::backend_deps`] | `tokio`, `serde`, `webbrowser`, `rand` |
@@ -519,7 +591,7 @@
 #[cfg(any(feature = "socket", feature = "socket-server", feature = "socket-client"))]
 pub mod socket;
 
-#[cfg(any(feature = "location", feature = "location-native"))]
+#[cfg(any(feature = "location", feature = "location-browser"))]
 pub mod location;
 
 #[cfg(feature = "serialization")]

--- a/src/location/backend_deps.rs
+++ b/src/location/backend_deps.rs
@@ -2,17 +2,17 @@
 //! sub-module (`browser`).
 //!
 //! Only available when the `backend-deps` feature is enabled together with
-//! `location` (or `location-native`).
+//! `location` (or `location-browser`).
 
 // browser sub-module deps
-#[cfg(feature = "location-native")]
+#[cfg(feature = "location-browser")]
 pub use tokio;
 
-#[cfg(feature = "location-native")]
+#[cfg(feature = "location-browser")]
 pub use serde;
 
-#[cfg(feature = "location-native")]
+#[cfg(feature = "location-browser")]
 pub use webbrowser;
 
-#[cfg(feature = "location-native")]
+#[cfg(feature = "location-browser")]
 pub use rand;

--- a/src/location/browser.rs
+++ b/src/location/browser.rs
@@ -741,3 +741,24 @@ fn render_page(template: &PageTemplate, key: &str) -> String {
         }
     }
 }
+
+/// Concise attribute macro alternative to calling [`__location__`] /
+/// [`__location_async__`] directly.
+///
+/// The function **name** becomes the binding; the [`PageTemplate`] is built
+/// from the macro arguments. See the
+/// [crate-level documentation](toolkit_zero::location) and
+/// [`toolkit_zero_macros::browser`] for the full argument reference.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use toolkit_zero::location::browser::{browser, LocationData, LocationError};
+///
+/// async fn run() -> Result<LocationData, LocationError> {
+///     #[browser(title = "My App", tickbox, consent = "I agree")]
+///     fn loc() {}
+///     Ok(loc)
+/// }
+/// ```
+pub use toolkit_zero_macros::browser;

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -17,16 +17,32 @@
 //!
 //! [Web Geolocation API]: https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 //!
+//! # Attribute macro
+//!
+//! The [`browser::browser`] attribute macro wraps the call to
+//! [`browser::__location__`] or [`browser::__location_async__`] and builds the
+//! [`browser::PageTemplate`] for you.
+//!
+//! ```rust,ignore
+//! use toolkit_zero::location::browser::{browser, LocationData, LocationError};
+//!
+//! async fn run() -> Result<LocationData, LocationError> {
+//!     #[browser(title = "My App")]
+//!     fn loc() {}
+//!     Ok(loc)
+//! }
+//! ```
+//!
 //! # Feature flag
 //!
-//! This module is compiled when the `location` (or `location-native`) feature is enabled:
+//! This module is compiled when the `location` (or `location-browser`) feature is enabled:
 //!
 //! ```toml
 //! [dependencies]
 //! toolkit-zero = { version = "...", features = ["location"] }
 //! ```
 
-#[cfg(feature = "location-native")]
+#[cfg(feature = "location-browser")]
 pub mod browser;
 
 #[cfg(feature = "backend-deps")]

--- a/src/serialization/backend_deps.rs
+++ b/src/serialization/backend_deps.rs
@@ -5,3 +5,4 @@
 
 pub use bincode;
 pub use base64;
+pub use zeroize;

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -59,8 +59,8 @@
 //! assert_eq!(p, back);
 //!
 //! // with an explicit key
-//! let blob2 = seal(&p, Some("my secret key")).unwrap();
-//! let back2: Point = open(&blob2, Some("my secret key")).unwrap();
+//! let blob2 = seal(&p, Some("my secret key".to_string())).unwrap();
+//! let back2: Point = open(&blob2, Some("my secret key".to_string())).unwrap();
 //! assert_eq!(p, back2);
 //! ```
 
@@ -68,6 +68,12 @@ mod veil;
 
 pub use veil::{seal, open, SerializationError};
 pub use bincode::{Encode, Decode};
+// Re-exported so that `#[serializable]` users don't need a direct `bincode` dep.
+// bincode's proc-macro derive generates code that resolves `bincode::` against
+// this path (via `#[bincode(crate = "::toolkit_zero::serialization::bincode")]`
+// injected by the macro).
+pub use bincode;
+pub use toolkit_zero_macros::{serializable, serialize, deserialize};
 
 #[cfg(feature = "backend-deps")]
 pub mod backend_deps;

--- a/src/serialization/veil.rs
+++ b/src/serialization/veil.rs
@@ -10,8 +10,7 @@ use bincode::{
     encode_to_vec, decode_from_slice,
     Encode, Decode,
     error::{EncodeError, DecodeError},
-};
-
+};use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 // ─── public error type ────────────────────────────────────────────────────────
 
 /// Errors returned by [`seal`] and [`open`].
@@ -59,14 +58,14 @@ const BLOCK: usize = 16;
 ///
 /// Returns [`SerializationError::Encode`] if `bincode` cannot serialize the
 /// value.
-pub fn seal<T: Encode>(value: &T, key: Option<&str>) -> Result<Vec<u8>, SerializationError> {
-    let key = key.unwrap_or(DEFAULT_KEY);
+pub fn seal<T: Encode>(value: &T, key: Option<String>) -> Result<Vec<u8>, SerializationError> {
+    let key: Zeroizing<String> = Zeroizing::new(key.unwrap_or_else(|| DEFAULT_KEY.to_string()));
 
-    // Step 0: struct → raw bytes via bincode
-    let plain = encode_to_vec(value, standard())?;
+    // Step 0: struct → raw bytes via bincode, wrapped for secure erasure
+    let plain: Zeroizing<Vec<u8>> = Zeroizing::new(encode_to_vec(value, standard())?);
 
     // Steps 1—5: VEIL forward transform
-    let cipher = veil_encrypt(&plain, key);
+    let cipher = veil_encrypt(&*plain, key.as_str());
 
     // Outer bincode framing: Vec<u8> → length-prefixed blob
     let blob = encode_to_vec(&cipher, standard())?;
@@ -81,17 +80,17 @@ pub fn seal<T: Encode>(value: &T, key: Option<&str>) -> Result<Vec<u8>, Serializ
 ///
 /// Returns [`SerializationError::Decode`] if the blob is malformed or the
 /// key is incorrect.
-pub fn open<T: Decode<()>>(blob: &[u8], key: Option<&str>) -> Result<T, SerializationError> {
-    let key = key.unwrap_or(DEFAULT_KEY);
+pub fn open<T: Decode<()>>(blob: &[u8], key: Option<String>) -> Result<T, SerializationError> {
+    let key: Zeroizing<String> = Zeroizing::new(key.unwrap_or_else(|| DEFAULT_KEY.to_string()));
 
     // Outer bincode unframing
     let (cipher, _): (Vec<u8>, _) = decode_from_slice(blob, standard())?;
 
-    // Steps 5—1 reversed
-    let plain = veil_decrypt(&cipher, key)?;
+    // Steps 5—1 reversed — returns Zeroizing<Vec<u8>> for secure erasure
+    let plain = veil_decrypt(&cipher, key.as_str())?;
 
     // raw bytes → struct via bincode
-    let (value, _): (T, _) = decode_from_slice(&plain, standard())?;
+    let (value, _): (T, _) = decode_from_slice(&plain[..], standard())?;
     Ok(value)
 }
 
@@ -122,19 +121,20 @@ fn veil_encrypt(plain: &[u8], key: &str) -> Vec<u8> {
 
 // ─── VEIL reverse (decrypt) ──────────────────────────────────────────────────
 
-fn veil_decrypt(cipher: &[u8], key: &str) -> Result<Vec<u8>, SerializationError> {
+fn veil_decrypt(cipher: &[u8], key: &str) -> Result<Zeroizing<Vec<u8>>, SerializationError> {
     let ks = KeySchedule::new(key);
 
-    let mut buf = cipher.to_vec();
+    // Wrap in Zeroizing so plaintext is wiped when this Vec is dropped
+    let mut buf: Zeroizing<Vec<u8>> = Zeroizing::new(cipher.to_vec());
 
     // 5 reverse: un-shuffle bytes within each 16-byte block
-    block_shuffle_reverse(&mut buf, &ks);
+    block_shuffle_reverse(&mut *buf, &ks);
 
     // 4 reverse: undo sequential accumulator
-    block_diffuse_reverse(&mut buf);
+    block_diffuse_reverse(&mut *buf);
 
     // 3 reverse: undo position mixing
-    position_mix_reverse(&mut buf);
+    position_mix_reverse(&mut *buf);
 
     // 2 reverse: XOR again with same key-stream (XOR is its own inverse)
     for (i, b) in buf.iter_mut().enumerate() {
@@ -154,6 +154,7 @@ fn veil_decrypt(cipher: &[u8], key: &str) -> Result<Vec<u8>, SerializationError>
 // All keying material is derived from a FNV-1a hash of the key string fed into
 // a splitmix64 PRNG.  No standard crypto hash or cipher is used.
 
+#[derive(Zeroize, ZeroizeOnDrop)]
 struct KeySchedule {
     /// Forward S-box: substitution table indexed by plaintext byte.
     sbox:     [u8; 256],
@@ -407,8 +408,8 @@ mod tests {
     #[test]
     fn round_trip_custom_key() {
         let p = Point { x: 42.0, y: 0.001, label: "custom".into() };
-        let blob = seal(&p, Some("hunter2")).unwrap();
-        let back: Point = open(&blob, Some("hunter2")).unwrap();
+        let blob = seal(&p, Some("hunter2".to_string())).unwrap();
+        let back: Point = open(&blob, Some("hunter2".to_string())).unwrap();
         assert_eq!(p, back);
     }
 
@@ -419,18 +420,18 @@ mod tests {
             inner: Point { x: -1.0, y: 2.5, label: "nested".into() },
             tags: vec!["a".into(), "bb".into(), "ccc".into()],
         };
-        let blob = seal(&n, Some("nested-key")).unwrap();
-        let back: Nested = open(&blob, Some("nested-key")).unwrap();
+        let blob = seal(&n, Some("nested-key".to_string())).unwrap();
+        let back: Nested = open(&blob, Some("nested-key".to_string())).unwrap();
         assert_eq!(n, back);
     }
 
     #[test]
     fn wrong_key_fails() {
         let p = Point { x: 1.0, y: 2.0, label: "x".into() };
-        let blob = seal(&p, Some("correct")).unwrap();
+        let blob = seal(&p, Some("correct".to_string())).unwrap();
         // Opening with wrong key should either error or produce garbage that
         // fails to decode as Point.
-        let result: Result<Point, _> = open(&blob, Some("wrong"));
+        let result: Result<Point, _> = open(&blob, Some("wrong".to_string()));
         assert!(result.is_err());
     }
 
@@ -446,8 +447,8 @@ mod tests {
     #[test]
     fn same_plaintext_same_key_produces_same_ciphertext() {
         let p = Point { x: 1.0, y: 2.0, label: "det".into() };
-        let b1 = seal(&p, Some("k")).unwrap();
-        let b2 = seal(&p, Some("k")).unwrap();
+        let b1 = seal(&p, Some("k".to_string())).unwrap();
+        let b2 = seal(&p, Some("k".to_string())).unwrap();
         assert_eq!(b1, b2); // cipher is deterministic
     }
 }

--- a/src/socket/client.rs
+++ b/src/socket/client.rs
@@ -34,7 +34,7 @@
 //! #[derive(Serialize)] struct Filter { page: u32 }
 //!
 //! # async fn run() -> Result<(), reqwest::Error> {
-//! let client = Client::new(Target::Localhost(8080));
+//! let client = Client::new_async(Target::Localhost(8080));
 //!
 //! // Plain async GET
 //! let items: Vec<Item> = client.get("/items").send().await?;

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -96,7 +96,7 @@
 //! # #[derive(Deserialize, Serialize)] struct Filter { page: u32 }
 //! # async fn example() -> Result<(), reqwest::Error> {
 //!
-//! let client = Client::new(Target::Localhost(8080));
+//! let client = Client::new_async(Target::Localhost(8080));
 //!
 //! // ── GET /items ───────────────────────────────────────────────────────────
 //! // Server:
@@ -169,10 +169,10 @@ pub enum SerializationKey {
 
 impl SerializationKey {
     #[doc(hidden)]
-    pub fn veil_key(&self) -> Option<&str> {
+    pub fn veil_key(&self) -> Option<String> {
         match self {
             Self::Default => None,
-            Self::Value(k) => Some(k.as_str()),
+            Self::Value(k) => Some(k.clone()),
         }
     }
 }

--- a/toolkit-zero-macros/Cargo.toml
+++ b/toolkit-zero-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toolkit-zero-macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Soumyo Deep Gupta <deep.main.ac@gmail.com>"]
@@ -21,6 +21,13 @@ maintenance = { status = "actively-developed" }
 default = []
 socket-server = []
 socket-client = []
+serialization = []
+location-browser = []
+enc-timelock-keygen-now         = []
+enc-timelock-keygen-input       = []
+enc-timelock-async-keygen-now   = []
+enc-timelock-async-keygen-input = []
+dep-graph-capture               = []
 
 [lib]
 proc-macro = true

--- a/toolkit-zero-macros/README.md
+++ b/toolkit-zero-macros/README.md
@@ -10,12 +10,14 @@ Procedural macros for [`toolkit-zero`](https://crates.io/crates/toolkit-zero).
 > |---|---|---|---|
 > | `#[mechanism]` | `socket-server` | `socket-server` | `toolkit_zero::socket::server::mechanism` |
 > | `#[request]` | `socket-client` | `socket-client` | `toolkit_zero::socket::client::request` |
+> | `#[serializable]` | `serialization` | `serialization` | `toolkit_zero::serialization::serializable` |
+> | `#[serialize]` | `serialization` | `serialization` | `toolkit_zero::serialization::serialize` |
+> | `#[deserialize]` | `serialization` | `serialization` | `toolkit_zero::serialization::deserialize` |
 >
-> Both are also available via `toolkit_zero::socket::prelude::*`.
+> `#[mechanism]` / `#[request]` are also available via `toolkit_zero::socket::prelude::*`.
 >
-> The `toolkit-zero-macros/socket-server` and `toolkit-zero-macros/socket-client` feature
-> gates are automatically activated by the corresponding `toolkit-zero` features — you do
-> not need to set them manually.
+> Feature gates are automatically activated by the corresponding `toolkit-zero` features —
+> you do not need to set them manually.
 
 ---
 
@@ -167,6 +169,122 @@ async fn example() -> Result<(), reqwest::Error> {
 
 ---
 
+## `#[serializable]` — derive + inject seal/open methods
+
+Automatically derives `bincode::Encode + bincode::Decode` on a struct or enum and
+injects `.seal(key)` / `::open(bytes, key)` methods. Field-level
+`#[serializable(key = "...")]` additionally generates per-field `seal_<field>` /
+`open_<field>` helpers with a hardcoded key.
+
+### Syntax
+
+```text
+#[serializable]
+struct Foo { ... }
+
+#[serializable]
+enum Bar { ... }
+
+#[serializable]
+struct Creds {
+    pub user: String,
+    #[serializable(key = "field-key")]
+    pub password: String,   // → seal_password / open_password
+}
+```
+
+### Injected methods
+
+```rust
+// Struct-level
+fn seal(&self, key: Option<String>) -> Result<Vec<u8>, SerializationError>
+fn open(bytes: &[u8], key: Option<String>) -> Result<Self, SerializationError>
+
+// Per annotated field
+fn seal_<field>(&self) -> Result<Vec<u8>, SerializationError>
+fn open_<field>(bytes: &[u8]) -> Result<FieldType, SerializationError>
+```
+
+### Example
+
+```rust
+use toolkit_zero::serialization::serializable;
+
+#[serializable]
+struct Config { host: String, port: u16 }
+
+let c = Config { host: "localhost".into(), port: 8080 };
+let blob = c.seal(None).unwrap();
+let back = Config::open(&blob, None).unwrap();
+```
+
+---
+
+## `#[serialize]` — inline seal statement
+
+Replaces a `fn` item with a seal statement. Two modes:
+
+- **Variable mode** — fn name → binding name, return type → type annotation (required).
+- **File write mode** — presence of `path = "..."` → `fs::write(path, seal(...)?)?`.
+
+### Syntax
+
+```text
+#[serialize(expr)]                              // variable, default key
+#[serialize(expr, key = key_expr)]              // variable, custom key
+#[serialize(expr, path = "file.bin")]           // file write, default key
+#[serialize(expr, path = "file.bin", key = k)]  // file write, custom key
+```
+
+### Example
+
+```rust
+use toolkit_zero::serialization::serialize;
+
+#[serialize(cfg, key = my_key)]
+fn blob() -> Vec<u8> {}
+// expands to: let blob: Vec<u8> = seal(&cfg, Some(my_key))?;
+
+#[serialize(cfg, path = "config.bin")]
+fn _() {}
+// expands to: fs::write("config.bin", seal(&cfg, None)?)?;
+```
+
+---
+
+## `#[deserialize]` — inline open statement
+
+Replaces a `fn` item with an open statement. The return type annotation is required.
+Two modes:
+
+- **Variable mode** — open from a blob expression in scope.
+- **File read mode** — presence of `path = "..."` → `open(&fs::read(path)?, ...)`.
+
+### Syntax
+
+```text
+#[deserialize(blob_expr)]                       // variable, default key
+#[deserialize(blob_expr, key = key_expr)]       // variable, custom key
+#[deserialize(path = "file.bin")]               // file read, default key
+#[deserialize(path = "file.bin", key = k)]      // file read, custom key
+```
+
+### Example
+
+```rust
+use toolkit_zero::serialization::deserialize;
+
+#[deserialize(blob, key = my_key)]
+fn config() -> Config {}
+// expands to: let config: Config = open::<Config>(&blob, Some(my_key))?;
+
+#[deserialize(path = "config.bin")]
+fn config() -> Config {}
+// expands to: let config: Config = open::<Config>(&fs::read("config.bin")?, None)?;
+```
+
+---
+
 ## Usage
 
 ```toml
@@ -177,155 +295,22 @@ toolkit-zero = { version = "3", features = ["socket-server"] }
 # Client-side macro
 toolkit-zero = { version = "3", features = ["socket-client"] }
 
-# Both
-toolkit-zero = { version = "3", features = ["socket"] }
+# Serialization macros
+toolkit-zero = { version = "3", features = ["serialization"] }
+
+# All socket + serialization
+toolkit-zero = { version = "3", features = ["socket", "serialization"] }
 ```
 
 ```rust
 // Server
 use toolkit_zero::socket::server::mechanism;
-// or
-use toolkit_zero::socket::prelude::*;  // includes both mechanism and request
-
 // Client
 use toolkit_zero::socket::client::request;
-// or
+// Serialization
+use toolkit_zero::serialization::{serializable, serialize, deserialize};
+// or all socket
 use toolkit_zero::socket::prelude::*;
-```
-
----
-
-## License
-
-MIT — same as `toolkit-zero`.
-
-
----
-
-## What this crate provides
-
-A single attribute macro — `#[mechanism]` — that is a concise shorthand for
-the `toolkit-zero` socket-server route builder chain.
-
-Instead of:
-
-```rust
-server.mechanism(
-    ServerMechanism::post("/items")
-        .json::<NewItem>()
-        .onconnect(|body: NewItem| async move {
-            reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
-        })
-);
-```
-
-you write:
-
-```rust
-#[mechanism(server, POST, "/items", json)]
-async fn create_item(body: NewItem) {
-    reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
-}
-```
-
-The macro expands to the exact same `server.mechanism(…)` statement in-place.
-The function name is discarded; the body is transplanted verbatim into the
-`.onconnect(…)` closure.
-
----
-
-## Usage
-
-Add `toolkit-zero` — **not** this crate — to your `Cargo.toml`:
-
-```toml
-[dependencies]
-toolkit-zero = { version = "3", features = ["socket-server"] }
-```
-
-Then import the macro from the server module:
-
-```rust
-use toolkit_zero::socket::server::mechanism;
-// or
-use toolkit_zero::socket::prelude::*;
-```
-
----
-
-## Supported forms
-
-| Attribute | Function parameters |
-|---|---|
-| `#[mechanism(server, METHOD, "/path")]` | `()` |
-| `#[mechanism(server, METHOD, "/path", json)]` | `(body: T)` |
-| `#[mechanism(server, METHOD, "/path", query)]` | `(params: T)` |
-| `#[mechanism(server, METHOD, "/path", encrypted(key))]` | `(body: T)` |
-| `#[mechanism(server, METHOD, "/path", encrypted_query(key))]` | `(params: T)` |
-| `#[mechanism(server, METHOD, "/path", state(expr))]` | `(state: S)` |
-| `#[mechanism(server, METHOD, "/path", state(expr), json)]` | `(state: S, body: T)` |
-| `#[mechanism(server, METHOD, "/path", state(expr), query)]` | `(state: S, params: T)` |
-| `#[mechanism(server, METHOD, "/path", state(expr), encrypted(key))]` | `(state: S, body: T)` |
-| `#[mechanism(server, METHOD, "/path", state(expr), encrypted_query(key))]` | `(state: S, params: T)` |
-
-Valid HTTP methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`.
-
-The keywords after the path (`json`, `query`, `state`, `encrypted`,
-`encrypted_query`) may appear in **any order**.
-
----
-
-## Full example
-
-```rust
-use toolkit_zero::socket::server::{Server, mechanism, reply, Status};
-use toolkit_zero::socket::SerializationKey;
-use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
-
-#[derive(Deserialize, Serialize, Clone)] struct Item    { id: u32, name: String }
-#[derive(Deserialize)]                   struct NewItem  { name: String }
-#[derive(Deserialize)]                   struct Filter   { page: u32 }
-
-#[tokio::main]
-async fn main() {
-    let mut server = Server::default();
-    let db: Arc<Mutex<Vec<Item>>> = Arc::new(Mutex::new(vec![]));
-
-    // Plain GET
-    #[mechanism(server, GET, "/health")]
-    async fn health() { reply!() }
-
-    // JSON body
-    #[mechanism(server, POST, "/items", json)]
-    async fn create(body: NewItem) {
-        reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
-    }
-
-    // Query params
-    #[mechanism(server, GET, "/items", query)]
-    async fn list(filter: Filter) {
-        let _ = filter.page;
-        reply!()
-    }
-
-    // State + JSON
-    #[mechanism(server, POST, "/items/add", state(db.clone()), json)]
-    async fn add(db: Arc<Mutex<Vec<Item>>>, body: NewItem) {
-        let id = db.lock().unwrap().len() as u32 + 1;
-        let item = Item { id, name: body.name };
-        db.lock().unwrap().push(item.clone());
-        reply!(json => item, status => Status::Created)
-    }
-
-    // VEIL-encrypted body
-    #[mechanism(server, POST, "/secure", encrypted(SerializationKey::Default))]
-    async fn secure(body: NewItem) {
-        reply!(json => Item { id: 99, name: body.name })
-    }
-
-    server.serve(([127, 0, 0, 1], 8080)).await;
-}
 ```
 
 ---

--- a/toolkit-zero-macros/src/browser_macro.rs
+++ b/toolkit-zero-macros/src/browser_macro.rs
@@ -1,0 +1,184 @@
+// ─── #[browser] ──────────────────────────────────────────────────────────────
+//
+// Attribute macro that replaces a decorated `fn` with an inline
+// `__location__` / `__location_async__` call.
+//
+// Syntax:
+//   #[browser]
+//   #[browser(sync)]
+//   #[browser(title = "…")]
+//   #[browser(body = "…")]
+//   #[browser(tickbox)]
+//   #[browser(tickbox, title = "…", body = "…", consent = "…")]
+//   #[browser(html = "…")]
+//   #[browser(sync, html = "…")]
+//   — any combination of `sync` + one template spec.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    Ident, ItemFn, LitStr, Token,
+};
+
+// ─── Argument struct ─────────────────────────────────────────────────────────
+
+struct BrowserArgs {
+    sync:    bool,
+    tickbox: bool,
+    title:   Option<LitStr>,
+    body:    Option<LitStr>,
+    consent: Option<LitStr>,
+    html:    Option<LitStr>,
+}
+
+impl Parse for BrowserArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut sync    = false;
+        let mut tickbox = false;
+        let mut title   = None::<LitStr>;
+        let mut body    = None::<LitStr>;
+        let mut consent = None::<LitStr>;
+        let mut html    = None::<LitStr>;
+
+        while !input.is_empty() {
+            // Peek at an identifier to determine which argument follows.
+            if input.peek(Ident) {
+                let ident: Ident = input.parse()?;
+                match ident.to_string().as_str() {
+                    "sync" => {
+                        sync = true;
+                    }
+                    "tickbox" => {
+                        tickbox = true;
+                    }
+                    "title" => {
+                        let _eq: Token![=] = input.parse()?;
+                        title = Some(input.parse()?);
+                    }
+                    "body" => {
+                        let _eq: Token![=] = input.parse()?;
+                        body = Some(input.parse()?);
+                    }
+                    "consent" => {
+                        let _eq: Token![=] = input.parse()?;
+                        consent = Some(input.parse()?);
+                    }
+                    "html" => {
+                        let _eq: Token![=] = input.parse()?;
+                        html = Some(input.parse()?);
+                    }
+                    other => {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            format!(
+                                "#[browser]: unknown argument `{other}`. \
+                                 Expected: sync, tickbox, title, body, consent, html"
+                            ),
+                        ));
+                    }
+                }
+            }
+
+            // Consume trailing comma, if present.
+            if input.peek(Token![,]) {
+                let _: Token![,] = input.parse()?;
+            }
+        }
+
+        Ok(BrowserArgs { sync, tickbox, title, body, consent, html })
+    }
+}
+
+// ─── Expansion ───────────────────────────────────────────────────────────────
+
+pub fn expand_browser(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = match syn::parse::<BrowserArgs>(attr) {
+        Ok(a)  => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let func = match syn::parse::<ItemFn>(item) {
+        Ok(f)  => f,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    // Validate: `html` is mutually exclusive with tickbox / title / body / consent.
+    if args.html.is_some()
+        && (args.tickbox
+            || args.title.is_some()
+            || args.body.is_some()
+            || args.consent.is_some())
+    {
+        return syn::Error::new_spanned(
+            &func.sig.ident,
+            "#[browser]: `html` is mutually exclusive with `tickbox`, `title`, `body`, and `consent`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let binding = &func.sig.ident;
+
+    // ── Build the PageTemplate token stream ──────────────────────────────────
+    let template_tokens = build_template(&args);
+
+    // ── Build the call expression ────────────────────────────────────────────
+    let call_tokens = if args.sync {
+        quote! {
+            let #binding = ::toolkit_zero::location::browser::__location__(#template_tokens)?;
+        }
+    } else {
+        quote! {
+            let #binding = ::toolkit_zero::location::browser::__location_async__(#template_tokens).await?;
+        }
+    };
+
+    call_tokens.into()
+}
+
+// ─── Template builder ────────────────────────────────────────────────────────
+
+fn build_template(args: &BrowserArgs) -> proc_macro2::TokenStream {
+    // Custom HTML variant.
+    if let Some(ref html_lit) = args.html {
+        return quote! {
+            ::toolkit_zero::location::browser::PageTemplate::Custom(
+                ::std::string::String::from(#html_lit)
+            )
+        };
+    }
+
+    // Title helper — Option<String> expression.
+    let title_expr = match &args.title {
+        Some(lit) => quote! { ::std::option::Option::Some(::std::string::String::from(#lit)) },
+        None      => quote! { ::std::option::Option::None },
+    };
+
+    // Body helper.
+    let body_expr = match &args.body {
+        Some(lit) => quote! { ::std::option::Option::Some(::std::string::String::from(#lit)) },
+        None      => quote! { ::std::option::Option::None },
+    };
+
+    if args.tickbox {
+        let consent_expr = match &args.consent {
+            Some(lit) => quote! { ::std::option::Option::Some(::std::string::String::from(#lit)) },
+            None      => quote! { ::std::option::Option::None },
+        };
+        quote! {
+            ::toolkit_zero::location::browser::PageTemplate::Tickbox {
+                title:        #title_expr,
+                body_text:    #body_expr,
+                consent_text: #consent_expr,
+            }
+        }
+    } else {
+        quote! {
+            ::toolkit_zero::location::browser::PageTemplate::Default {
+                title:     #title_expr,
+                body_text: #body_expr,
+            }
+        }
+    }
+}

--- a/toolkit-zero-macros/src/dependencies_macro.rs
+++ b/toolkit-zero-macros/src/dependencies_macro.rs
@@ -1,0 +1,79 @@
+// ─── #[dependencies] ──────────────────────────────────────────────────────────
+//
+// Attribute macro that replaces a decorated empty `fn` with an inline
+// `capture::parse(…)?` or `capture::as_bytes(…)` call, embedding the
+// build-time fingerprint JSON via `include_str!`.
+//
+// The function name becomes the `let` binding name in the expansion.
+//
+// Parse mode (default — returns BuildTimeFingerprintData via `?`):
+//   #[dependencies]
+//   fn data() {}
+//
+// Bytes mode (returns &'static [u8], no `?`):
+//   #[dependencies(bytes)]
+//   fn raw() {}
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    Ident, ItemFn,
+};
+
+// ─── args ─────────────────────────────────────────────────────────────────────
+
+struct DepsArgs {
+    bytes_mode: bool,
+}
+
+impl Parse for DepsArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(DepsArgs { bytes_mode: false });
+        }
+        let ident: Ident = input.parse()?;
+        match ident.to_string().as_str() {
+            "bytes" => Ok(DepsArgs { bytes_mode: true }),
+            other => Err(syn::Error::new(
+                ident.span(),
+                format!("#[dependencies]: unknown option `{other}`; expected `bytes`"),
+            )),
+        }
+    }
+}
+
+// ─── expander ─────────────────────────────────────────────────────────────────
+
+pub fn expand_dependencies(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = match syn::parse::<DepsArgs>(attr) {
+        Ok(a)  => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let func = match syn::parse::<ItemFn>(item) {
+        Ok(f)  => f,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let binding = &func.sig.ident;
+    let cap = quote! { ::toolkit_zero::dependency_graph::capture };
+
+    let expanded: TokenStream2 = if args.bytes_mode {
+        quote! {
+            const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+                include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+            let #binding: &'static [u8] =
+                #cap::as_bytes(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__);
+        }
+    } else {
+        quote! {
+            const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+                include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+            let #binding = #cap::parse(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__)?;
+        }
+    };
+
+    expanded.into()
+}

--- a/toolkit-zero-macros/src/lib.rs
+++ b/toolkit-zero-macros/src/lib.rs
@@ -1,785 +1,1068 @@
 //! Procedural macros for `toolkit-zero`.
 //!
 //! This crate is an internal implementation detail of `toolkit-zero`.
-//! Do not depend on it directly. Use the re-exported attribute macros:
+//! Do not depend on it directly — all macros are re-exported through the
+//! relevant `toolkit-zero` module:
 //!
-//! - [`mechanism`] — server-side route declaration, via `toolkit_zero::socket::server`
-//! - [`request`]   — client-side request shorthand, via `toolkit_zero::socket::client`
+//! | Macro | Enable with | Import from |
+//! |---|---|---|
+//! | [`mechanism`] | `features = ["socket-server"]` | `toolkit_zero::socket::server` |
+//! | [`request`] | `features = ["socket-client"]` | `toolkit_zero::socket::client` |
+//! | [`serializable`] | `features = ["serialization"]` | `toolkit_zero::serialization` |
+//! | [`serialize`] | `features = ["serialization"]` | `toolkit_zero::serialization` |
+//! | [`deserialize`] | `features = ["serialization"]` | `toolkit_zero::serialization` |
+//! | [`browser`] | `features = ["location"]` | `toolkit_zero::location` |
+//! | [`timelock`] | any `enc-timelock-*` feature | `toolkit_zero::encryption::timelock` |
+//! | [`dependencies`] | `features = ["dependency-graph-capture"]` | `toolkit_zero::dependency_graph::capture` |
+//!
+//! ---
+//!
+//! # `#[mechanism]` — server-side route declaration
+//!
+//! Replaces a decorated `fn` item with a `server.mechanism(…)` builder
+//! statement. The function body is transplanted verbatim into the
+//! `.onconnect(…)` closure; all variables from the enclosing scope are
+//! accessible via `move` capture.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! #[mechanism(server, METHOD, "/path")]
+//! #[mechanism(server, METHOD, "/path", json)]
+//! #[mechanism(server, METHOD, "/path", query)]
+//! #[mechanism(server, METHOD, "/path", encrypted(<key_expr>))]
+//! #[mechanism(server, METHOD, "/path", encrypted_query(<key_expr>))]
+//! #[mechanism(server, METHOD, "/path", state(<state_expr>))]
+//! #[mechanism(server, METHOD, "/path", state(<state_expr>), json)]
+//! #[mechanism(server, METHOD, "/path", state(<state_expr>), query)]
+//! #[mechanism(server, METHOD, "/path", state(<state_expr>), encrypted(<key_expr>))]
+//! #[mechanism(server, METHOD, "/path", state(<state_expr>), encrypted_query(<key_expr>))]
+//! ```
+//!
+//! The first three arguments (`server`, `METHOD`, `"/path"`) are positional
+//! and required. Keywords after the path (`json`, `query`, `state(…)`,
+//! `encrypted(…)`, `encrypted_query(…)`) may appear in **any order**.
+//!
+//! ## Parameters
+//!
+//! | Argument | Type | Description |
+//! |---|---|---|
+//! | `server` | ident | The [`Server`](toolkit_zero::socket::server::Server) variable in scope |
+//! | `METHOD` | ident | HTTP verb: `GET` `POST` `PUT` `DELETE` `PATCH` `HEAD` `OPTIONS` |
+//! | `"/path"` | string literal | Route path |
+//! | `json` | keyword | Deserialise JSON body; fn receives `(body: T)` |
+//! | `query` | keyword | Deserialise URL query params; fn receives `(params: T)` |
+//! | `encrypted(key)` | keyword + expr | VEIL-decrypt body; fn receives `(body: T)` |
+//! | `encrypted_query(key)` | keyword + expr | VEIL-decrypt query; fn receives `(params: T)` |
+//! | `state(expr)` | keyword + expr | Clone state into handler; fn first param is `(state: S)` |
+//!
+//! When `state` is combined with a body mode, the function receives two
+//! parameters: state first, then body/params.
+//!
+//! ## Function signature rules
+//!
+//! - The function **may** be `async` or non-async — it is always wrapped in `async move { … }`.
+//! - The return type annotation is ignored; Rust infers it from the `reply!` macro inside the body.
+//! - The number of parameters must match the chosen mode exactly (compile error otherwise).
+//!
+//! ## What the macro expands to
+//!
+//! ```rust,ignore
+//! // Input:
+//! #[mechanism(server, POST, "/items", json)]
+//! async fn create(body: NewItem) {
+//!     reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
+//! }
+//!
+//! // Expanded to:
+//! server.mechanism(
+//!     toolkit_zero::socket::server::ServerMechanism::post("/items")
+//!         .json::<NewItem>()
+//!         .onconnect(|body: NewItem| async move {
+//!             reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
+//!         })
+//! );
+//! ```
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use toolkit_zero::socket::server::{Server, mechanism, reply, Status, SerializationKey};
+//! use serde::{Deserialize, Serialize};
+//! use std::sync::{Arc, Mutex};
+//!
+//! #[derive(Deserialize, Serialize, Clone)] struct Item    { id: u32, name: String }
+//! #[derive(Deserialize)]                   struct NewItem  { name: String }
+//! #[derive(Deserialize)]                   struct Filter   { page: u32 }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let mut server = Server::default();
+//!     let db: Arc<Mutex<Vec<Item>>> = Arc::new(Mutex::new(vec![]));
+//!
+//!     // Plain GET — no body
+//!     #[mechanism(server, GET, "/health")]
+//!     async fn health() { reply!() }
+//!
+//!     // JSON body
+//!     #[mechanism(server, POST, "/items", json)]
+//!     async fn create(body: NewItem) {
+//!         reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
+//!     }
+//!
+//!     // URL query params
+//!     #[mechanism(server, GET, "/items", query)]
+//!     async fn list(filter: Filter) {
+//!         let _ = filter.page;
+//!         reply!()
+//!     }
+//!
+//!     // Shared state + JSON body
+//!     #[mechanism(server, POST, "/items/add", state(db.clone()), json)]
+//!     async fn add(db: Arc<Mutex<Vec<Item>>>, body: NewItem) {
+//!         let id = db.lock().unwrap().len() as u32 + 1;
+//!         db.lock().unwrap().push(Item { id, name: body.name.clone() });
+//!         reply!(json => Item { id, name: body.name }, status => Status::Created)
+//!     }
+//!
+//!     // VEIL-encrypted body
+//!     #[mechanism(server, POST, "/secure", encrypted(SerializationKey::Default))]
+//!     async fn secure(body: NewItem) {
+//!         reply!(json => Item { id: 99, name: body.name })
+//!     }
+//!
+//!     server.serve(([127, 0, 0, 1], 8080)).await;
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[request]` — client-side request shorthand
+//!
+//! Replaces a decorated `fn` item with an inline `let` binding that performs
+//! an HTTP request. The **function name** becomes the binding name; the
+//! **return type** becomes `R` in the `.send::<R>()` turbofish. The function
+//! body is discarded entirely.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! #[request(client, METHOD, "/path", async|sync)]
+//! #[request(client, METHOD, "/path", json(<body_expr>), async|sync)]
+//! #[request(client, METHOD, "/path", query(<params_expr>), async|sync)]
+//! #[request(client, METHOD, "/path", encrypted(<body_expr>, <key_expr>), async|sync)]
+//! #[request(client, METHOD, "/path", encrypted_query(<params_expr>, <key_expr>), async|sync)]
+//! ```
+//!
+//! The first three arguments are positional. The mode keyword (if any) comes
+//! before the mandatory `async` or `sync` terminator.
+//!
+//! ## Parameters
+//!
+//! | Argument | Description |
+//! |---|---|
+//! | `client` | The [`Client`](toolkit_zero::socket::client::Client) variable in scope |
+//! | `METHOD` | HTTP verb: `GET` `POST` `PUT` `DELETE` `PATCH` `HEAD` `OPTIONS` |
+//! | `"/path"` | Endpoint path string literal |
+//! | `json(expr)` | Serialise `expr` as a JSON body (`Content-Type: application/json`) |
+//! | `query(expr)` | Serialise `expr` as URL query parameters |
+//! | `encrypted(body, key)` | VEIL-seal `body` with `key` before sending |
+//! | `encrypted_query(params, key)` | VEIL-seal `params`, send as `?data=<base64url>` |
+//! | `async` | Finalise with `.send::<R>().await?` |
+//! | `sync` | Finalise with `.send_sync::<R>()?` |
+//!
+//! ## Requirements
+//!
+//! - A **return type annotation is required** — it is used as `R` in the turbofish.
+//!   Omitting it is a compile error.
+//! - The enclosing function must return `Result<_, E>` where `E: From<reqwest::Error>`
+//!   (plain/json/query modes) or `E: From<ClientError>` (encrypted modes), so that
+//!   `?` can propagate.
+//!
+//! ## What the macro expands to
+//!
+//! ```rust,ignore
+//! // Input:
+//! #[request(client, POST, "/items", json(NewItem { name: "widget".into() }), async)]
+//! async fn created() -> Item {}
+//!
+//! // Expanded to:
+//! let created: Item = client.post("/items")
+//!     .json(NewItem { name: "widget".into() })
+//!     .send::<Item>()
+//!     .await?;
+//! ```
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use toolkit_zero::socket::client::{Client, Target, request};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Deserialize, Serialize)] struct Item    { id: u32, name: String }
+//! #[derive(Serialize)]              struct NewItem  { name: String }
+//! #[derive(Serialize)]              struct Filter   { page: u32 }
+//!
+//! async fn example() -> Result<(), reqwest::Error> {
+//!     let client = Client::new_async(Target::Localhost(8080));
+//!
+//!     // GET → let items: Vec<Item> = client.get("/items").send::<Vec<Item>>().await?
+//!     #[request(client, GET, "/items", async)]
+//!     async fn items() -> Vec<Item> {}
+//!
+//!     // POST with JSON body
+//!     #[request(client, POST, "/items", json(NewItem { name: "widget".into() }), async)]
+//!     async fn created() -> Item {}
+//!
+//!     // GET with query params
+//!     #[request(client, GET, "/items", query(Filter { page: 2 }), async)]
+//!     async fn page() -> Vec<Item> {}
+//!
+//!     // Synchronous DELETE
+//!     #[request(client, DELETE, "/items/1", sync)]
+//!     fn deleted() -> Item {}
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[serializable]` — derive + inject seal/open
+//!
+//! Automatically derives `bincode::Encode + bincode::Decode` on a struct or
+//! enum and injects three methods:
+//!
+//! ```text
+//! fn seal(&self, key: Option<String>) -> Result<Vec<u8>, SerializationError>
+//! fn open(bytes: &[u8], key: Option<String>) -> Result<Self, SerializationError>
+//! ```
+//!
+//! The `key` is **moved in** and internally wrapped in `Zeroizing<String>`,
+//! wiping it from memory on drop.  Pass `None` to use the built-in default key.
+//!
+//! Field-level `#[serializable(key = "literal")]` additionally generates
+//! per-field helpers with the key baked in:
+//!
+//! ```text
+//! fn seal_<field>(&self)        -> Result<Vec<u8>, SerializationError>
+//! fn open_<field>(bytes: &[u8]) -> Result<FieldType, SerializationError>
+//! ```
+//!
+//! ## Syntax
+//!
+//! ```text
+//! #[serializable]                      // on a struct or enum
+//! struct Foo { … }
+//!
+//! #[serializable]                      // field annotation inside a struct
+//! struct Bar {
+//!     pub normal: String,
+//!     #[serializable(key = "my-key")]  // generates seal_secret / open_secret
+//!     pub secret: String,
+//! }
+//! ```
+//!
+//! > **Note:** `#[serializable]` on an enum does not scan fields for the
+//! > field-level annotation — only named struct fields are supported for
+//! > per-field helpers.
+//!
+//! ## What the macro expands to
+//!
+//! ```rust,ignore
+//! // Input:
+//! #[serializable]
+//! struct Config { host: String, port: u16 }
+//!
+//! // Expanded to:
+//! #[derive(::toolkit_zero::serialization::Encode, ::toolkit_zero::serialization::Decode)]
+//! struct Config { host: String, port: u16 }
+//!
+//! impl Config {
+//!     pub fn seal(&self, key: Option<String>) -> Result<Vec<u8>, SerializationError> {
+//!         ::toolkit_zero::serialization::seal(self, key)
+//!     }
+//!     pub fn open(bytes: &[u8], key: Option<String>) -> Result<Self, SerializationError> {
+//!         ::toolkit_zero::serialization::open::<Self>(bytes, key)
+//!     }
+//! }
+//! ```
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use toolkit_zero::serialization::serializable;
+//!
+//! #[serializable]
+//! struct Config { host: String, port: u16 }
+//!
+//! let c = Config { host: "localhost".into(), port: 8080 };
+//!
+//! // Seal / open via struct methods
+//! let blob = c.seal(None).unwrap();
+//! let back = Config::open(&blob, None).unwrap();
+//! assert_eq!(c.host, back.host);
+//!
+//! // Custom key — moved in, zeroized on drop
+//! let blob2 = c.seal(Some("secret".to_string())).unwrap();
+//! let back2 = Config::open(&blob2, Some("secret".to_string())).unwrap();
+//!
+//! // Per-field annotation
+//! #[serializable]
+//! struct Creds {
+//!     pub user: String,
+//!     #[serializable(key = "field-secret")]
+//!     pub password: String,
+//! }
+//!
+//! let creds = Creds { user: "alice".into(), password: "hunter2".into() };
+//! let pw_blob = creds.seal_password().unwrap();    // key baked in
+//! let pw_back = Creds::open_password(&pw_blob).unwrap();
+//! assert_eq!("hunter2", pw_back);
+//! ```
+//!
+//! ---
+//!
+//! # `#[serialize]` — inline seal statement
+//!
+//! Replaces a `fn` item with an inline seal statement. Two modes are
+//! selected by the presence or absence of `path`:
+//!
+//! - **Variable mode** (`path` absent) — emits a `let` binding. The function
+//!   name becomes the variable name; the **return type is required** and
+//!   becomes the type annotation. The function body is discarded.
+//! - **File write mode** (`path = "..."` present) — emits
+//!   `std::fs::write(path, seal(…)?)?`. The function name and return type are
+//!   ignored.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! // Variable mode
+//! #[serialize(source_expr)]
+//! #[serialize(source_expr, key = key_expr)]
+//!
+//! // File write mode  
+//! #[serialize(source_expr, path = "file.bin")]
+//! #[serialize(source_expr, path = "file.bin", key = key_expr)]
+//! ```
+//!
+//! | Argument | Required | Description |
+//! |---|---|---|
+//! | `source_expr` | yes | Expression to seal (must be `bincode::Encode`) |
+//! | `key = expr` | no | Key expression — `Option<String>` moved into `seal()` |
+//! | `path = "..."` | no | File path — switches to file write mode |
+//!
+//! `key` and `path` may appear in any order after `source_expr`.
+//!
+//! ## What the macro expands to
+//!
+//! ```rust,ignore
+//! // Variable mode:
+//! #[serialize(cfg, key = my_key)]
+//! fn blob() -> Vec<u8> {}
+//! // →
+//! let blob: Vec<u8> = ::toolkit_zero::serialization::seal(&cfg, Some(my_key))?;
+//!
+//! // Variable mode, default key:
+//! #[serialize(cfg)]
+//! fn blob() -> Vec<u8> {}
+//! // →
+//! let blob: Vec<u8> = ::toolkit_zero::serialization::seal(&cfg, None)?;
+//!
+//! // File write mode:
+//! #[serialize(cfg, path = "out.bin", key = my_key)]
+//! fn _() {}
+//! // →
+//! ::std::fs::write("out.bin", ::toolkit_zero::serialization::seal(&cfg, Some(my_key))?)?;
+//! ```
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use toolkit_zero::serialization::{serializable, serialize};
+//!
+//! #[serializable]
+//! struct Config { threshold: f64 }
+//!
+//! fn save(cfg: &Config, key: String) -> Result<(), Box<dyn std::error::Error>> {
+//!     // Seal to a variable
+//!     #[serialize(cfg, key = key.clone())]
+//!     fn blob() -> Vec<u8> {}
+//!     // blob: Vec<u8> is now in scope
+//!
+//!     // Write directly to a file
+//!     #[serialize(cfg, path = "config.bin", key = key)]
+//!     fn _() {}
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[deserialize]` — inline open statement
+//!
+//! Replaces a `fn` item with an inline open statement. Two modes:
+//!
+//! - **Variable mode** (`path` absent) — opens from a blob expression already
+//!   in scope. The function name becomes the binding name; the **return type
+//!   is required** and used as the turbofish type `T` in `open::<T>`.
+//! - **File read mode** (`path = "..."` present) — reads the file first, then
+//!   opens. Same name/return-type rules apply.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! // Variable mode
+//! #[deserialize(blob_expr)]
+//! #[deserialize(blob_expr, key = key_expr)]
+//!
+//! // File read mode
+//! #[deserialize(path = "file.bin")]
+//! #[deserialize(path = "file.bin", key = key_expr)]
+//! ```
+//!
+//! | Argument | Required | Description |
+//! |---|---|---|
+//! | `blob_expr` | yes (variable mode) | Expression whose value is `&[u8]` (reference taken automatically) |
+//! | `path = "..."` | yes (file mode) | File to read; switches to file read mode |
+//! | `key = expr` | no | Key expression — `Option<String>` moved into `open()` |
+//!
+//! ## What the macro expands to
+//!
+//! ```rust,ignore
+//! // Variable mode:
+//! #[deserialize(blob, key = my_key)]
+//! fn config() -> Config {}
+//! // →
+//! let config: Config = ::toolkit_zero::serialization::open::<Config>(&blob, Some(my_key))?;
+//!
+//! // Variable mode, default key:
+//! #[deserialize(blob)]
+//! fn config() -> Config {}
+//! // →
+//! let config: Config = ::toolkit_zero::serialization::open::<Config>(&blob, None)?;
+//!
+//! // File read mode:
+//! #[deserialize(path = "config.bin", key = my_key)]
+//! fn config() -> Config {}
+//! // →
+//! let config: Config = ::toolkit_zero::serialization::open::<Config>(
+//!     &::std::fs::read("config.bin")?,
+//!     Some(my_key),
+//! )?;
+//! ```
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use toolkit_zero::serialization::{serializable, serialize, deserialize};
+//!
+//! #[serializable]
+//! struct Config { threshold: f64 }
+//!
+//! fn round_trip(cfg: &Config, key: String) -> Result<Config, Box<dyn std::error::Error>> {
+//!     // Write to disk
+//!     #[serialize(cfg, path = "config.bin", key = key.clone())]
+//!     fn _() {}
+//!
+//!     // Read back
+//!     #[deserialize(path = "config.bin", key = key)]
+//!     fn loaded() -> Config {}
+//!
+//!     Ok(loaded)
+//! }
+//!
+//! fn from_bytes(blob: Vec<u8>) -> Result<Config, Box<dyn std::error::Error>> {
+//!     #[deserialize(blob)]
+//!     fn cfg() -> Config {}
+//!
+//!     Ok(cfg)
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[browser]` — inline location capture
+//!
+//! Replaces a `fn` item with an inline call to either
+//! [`__location__`](toolkit_zero::location::browser::__location__) (sync) or
+//! [`__location_async__`](toolkit_zero::location::browser::__location_async__)
+//! (async, default). The [`PageTemplate`](toolkit_zero::location::browser::PageTemplate)
+//! is built from the macro arguments — no need to construct it manually.
+//!
+//! The function **name** becomes the binding that holds the resulting
+//! [`LocationData`](toolkit_zero::location::browser::LocationData).
+//! The function **body** is discarded. A `?` is appended so any
+//! [`LocationError`](toolkit_zero::location::browser::LocationError) propagates
+//! to the enclosing function.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! #[browser]                                        // async, Default template
+//! #[browser(sync)]                                  // blocking, Default template
+//! #[browser(title = "My App")]                      // async, Default, custom title
+//! #[browser(title = "T", body = "B")]               // async, Default, title + body
+//! #[browser(tickbox)]                               // async, Tickbox template (all defaults)
+//! #[browser(tickbox, title = "T", consent = "C")]   // async, Tickbox with arguments
+//! #[browser(html = "<html>…</html>")]               // async, Custom template
+//! #[browser(sync, html = "…")]                      // sync + Custom template
+//! ```
+//!
+//! All arguments are optional and may appear in **any order**.
+//!
+//! ## Arguments
+//!
+//! | Argument | Type | Notes |
+//! |---|---|---|
+//! | `sync` | flag | Use the blocking `__location__` function; default uses `__location_async__().await` |
+//! | `tickbox` | flag | Use `PageTemplate::Tickbox`; incompatible with `html` |
+//! | `title = "…"` | string literal | Tab/heading title for Default or Tickbox |
+//! | `body = "…"` | string literal | Body paragraph text for Default or Tickbox |
+//! | `consent = "…"` | string literal | Checkbox label for Tickbox only |
+//! | `html = "…"` | string literal | Use `PageTemplate::Custom`; **mutually exclusive** with all other template args |
+//!
+//! ## Expansion examples
+//!
+//! ```rust,ignore
+//! use toolkit_zero::location::{browser, LocationData};
+//!
+//! // Async, Default template with a custom title:
+//! async fn get_loc() -> Result<LocationData, Box<dyn std::error::Error>> {
+//!     #[browser(title = "My App")]
+//!     fn loc() {}
+//!     // expands to:
+//!     // let loc = ::toolkit_zero::location::browser::__location_async__(
+//!     //     ::toolkit_zero::location::browser::PageTemplate::Default {
+//!     //         title:     Some("My App".to_string()),
+//!     //         body_text: None,
+//!     //     }
+//!     // ).await?;
+//!     Ok(loc)
+//! }
+//!
+//! // Sync, Tickbox with consent text:
+//! fn get_loc_sync() -> Result<LocationData, Box<dyn std::error::Error>> {
+//!     #[browser(sync, tickbox, consent = "I agree")]
+//!     fn loc() {}
+//!     // expands to:
+//!     // let loc = ::toolkit_zero::location::browser::__location__(
+//!     //     ::toolkit_zero::location::browser::PageTemplate::Tickbox {
+//!     //         title:        None,
+//!     //         body_text:    None,
+//!     //         consent_text: Some("I agree".to_string()),
+//!     //     }
+//!     // )?;
+//!     Ok(loc)
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[timelock]` — inline key derivation
+//!
+//! Replaces a `fn` item with an inline call to either
+//! [`timelock`](toolkit_zero::encryption::timelock::timelock) (sync) or
+//! [`timelock_async`](toolkit_zero::encryption::timelock::timelock_async)
+//! (async — add the `async` flag). The 7 positional `Option<…>` arguments
+//! are built from named keyword arguments, and the correct path
+//! (*encryption* or *decryption*) is selected automatically.
+//!
+//! The function **name** becomes the binding; the function **body** is
+//! discarded. A `?` propagates any
+//! [`TimeLockError`](toolkit_zero::encryption::timelock::TimeLockError).
+//!
+//! ## Two paths
+//!
+//! | Path | Supply | Required args |
+//! |---|---|---|
+//! | **Encryption** | Explicit time → derive key | `precision`, `format`, `time`, `salts`, `kdf` |
+//! | **Decryption** | Stored header → same key | `params` (a [`TimeLockParams`](toolkit_zero::encryption::timelock::TimeLockParams)) |
+//!
+//! ## Syntax
+//!
+//! ```text
+//! // Encryption path
+//! #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+//! #[timelock(precision = Hour, format = Hour24, time(9, 0), salts = s, kdf = k,
+//!            cadence = DayOfWeek(Tuesday))]
+//! #[timelock(async, precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+//!
+//! // Decryption path
+//! #[timelock(params = header)]
+//! #[timelock(async, params = header)]
+//! ```
+//!
+//! All arguments are keyword-based and may appear in **any order**.
+//!
+//! ## Arguments
+//!
+//! | Argument | Type | Notes |
+//! |---|---|---|
+//! | `async` | flag | Use `timelock_async().await?`; default uses `timelock()?` |
+//! | `params = expr` | `TimeLockParams` | **Decryption path.** Mutually exclusive with all other args |
+//! | `precision = …` | `Hour` \| `Quarter` \| `Minute` | Encryption. Time quantisation level |
+//! | `format = …` | `Hour12` \| `Hour24` | Encryption. Clock representation |
+//! | `time(h, m)` | two int literals | Encryption. Target time (24-hour `h` 0–23, `m` 0–59) |
+//! | `cadence = …` | see below | Optional. Calendar constraint; defaults to `None` |
+//! | `salts = expr` | `TimeLockSalts` | Encryption. Three 32-byte KDF salts |
+//! | `kdf = expr` | `KdfParams` | Encryption. KDF work-factor parameters |
+//!
+//! ## Cadence variants
+//!
+//! ```text
+//! cadence = None
+//! cadence = DayOfWeek(Tuesday)
+//! cadence = DayOfMonth(15)
+//! cadence = MonthOfYear(January)
+//! cadence = DayOfWeekInMonth(Tuesday, January)
+//! cadence = DayOfMonthInMonth(15, January)
+//! cadence = DayOfWeekAndDayOfMonth(Tuesday, 15)
+//! ```
+//!
+//! ## Expansion examples
+//!
+//! ```rust,ignore
+//! use toolkit_zero::encryption::timelock::*;
+//!
+//! // Encryption — derive key for 14:37 with Minute precision.
+//! fn encrypt() -> Result<TimeLockKey, TimeLockError> {
+//!     let salts = TimeLockSalts::generate();
+//!     let kdf   = KdfPreset::Balanced.params();
+//!
+//!     #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = salts, kdf = kdf)]
+//!     fn enc_key() {}
+//!     // let enc_key = timelock(
+//!     //     Some(TimeLockCadence::None),
+//!     //     Some(TimeLockTime::new(14, 37).unwrap()),
+//!     //     Some(TimePrecision::Minute),
+//!     //     Some(TimeFormat::Hour24),
+//!     //     Some(salts), Some(kdf), None,
+//!     // )?;
+//!     Ok(enc_key)
+//! }
+//!
+//! // Decryption — re-derive from a stored header.
+//! fn decrypt(header: TimeLockParams) -> Result<TimeLockKey, TimeLockError> {
+//!     #[timelock(params = header)]
+//!     fn dec_key() {}
+//!     // let dec_key = timelock(None, None, None, None, None, None, Some(header))?;
+//!     Ok(dec_key)
+//! }
+//!
+//! // Async encryption with a calendar cadence (Tuesdays only).
+//! async fn async_encrypt() -> Result<TimeLockKey, TimeLockError> {
+//!     let salts = TimeLockSalts::generate();
+//!     let kdf   = KdfPreset::BalancedMac.params();
+//!
+//!     #[timelock(async,
+//!                precision = Minute, format = Hour24, time(14, 37),
+//!                cadence = DayOfWeek(Tuesday),
+//!                salts = salts, kdf = kdf)]
+//!     fn enc_key() {}
+//!     Ok(enc_key)
+//! }
+//! ```
+//!
+//! ---
+//!
+//! # `#[dependencies]` — build-time fingerprint capture
+//!
+//! Embeds the `fingerprint.json` produced by `generate_fingerprint()` (feature
+//! `dependency-graph-build`) into the binary and binds either the parsed
+//! [`BuildTimeFingerprintData`](toolkit_zero::dependency_graph::capture::BuildTimeFingerprintData)
+//! or the raw `&'static [u8]` JSON bytes.
+//!
+//! Apply the attribute to an **empty `fn`** inside a function body; the
+//! function name becomes the `let` binding name. Requires the
+//! `dependency-graph-capture` feature.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! #[dependencies]           // parse mode  → BuildTimeFingerprintData (propagates ?)
+//! #[dependencies(bytes)]    // bytes mode  → &'static [u8]  (infallible)
+//! ```
+//!
+//! ## Expansion
+//!
+//! Both modes expand to a `const` embedding followed by a `let` binding:
+//!
+//! ```rust,ignore
+//! // Parse mode:
+//! // const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+//! //     include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+//! // let <binding> = capture::parse(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__)?;
+//!
+//! // Bytes mode:
+//! // const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+//! //     include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+//! // let <binding>: &'static [u8] = capture::as_bytes(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__);
+//! ```
+//!
+//! ## Examples
+//!
+//! ```rust,ignore
+//! use toolkit_zero::dependency_graph::capture::dependencies;
+//!
+//! fn show_info() -> Result<(), Box<dyn std::error::Error>> {
+//!     #[dependencies]
+//!     fn data() {}
+//!     println!("{} v{}", data.package.name, data.package.version);
+//!     println!("target  : {}", data.build.target);
+//!     println!("lock    : {}", data.cargo_lock_sha256);
+//!     Ok(())
+//! }
+//!
+//! fn raw_bytes() -> &'static [u8] {
+//!     #[dependencies(bytes)]
+//!     fn raw() {}
+//!     raw
+//! }
+//! ```
 
-#[cfg(any(feature = "socket-server", feature = "socket-client"))]
+#[allow(unused)]
 use proc_macro::TokenStream;
-#[cfg(any(feature = "socket-server", feature = "socket-client"))]
-use quote::quote;
-#[cfg(any(feature = "socket-server", feature = "socket-client"))]
-use syn::{
-    parse::{Parse, ParseStream},
-    parse_macro_input, Expr, Ident, ItemFn, LitStr, Token,
-};
-
-// ─── Argument types ───────────────────────────────────────────────────────────
 
 #[cfg(feature = "socket-server")]
-/// The body/query mode keyword extracted from the attribute arguments.
-enum BodyMode {
-    None,
-    Json,
-    Query,
-    Encrypted(Expr),
-    EncryptedQuery(Expr),
-}
+mod mechanism;
+#[cfg(feature = "socket-client")]
+mod request_macro;
+#[cfg(feature = "serialization")]
+mod serialization_macro;
 
-#[cfg(feature = "socket-server")]
-/// Fully parsed attribute arguments.
-struct MechanismArgs {
-    /// The `Server` variable identifier in the enclosing scope.
-    server: Ident,
-    /// HTTP method identifier (GET, POST, …).
-    method: Ident,
-    /// Route path string literal.
-    path: LitStr,
-    /// Optional `state(expr)` argument.
-    state: Option<Expr>,
-    /// How the request body / query is processed.
-    body_mode: BodyMode,
-}
+// ─── socket-server ────────────────────────────────────────────────────────────
 
-#[cfg(feature = "socket-server")]
-impl Parse for MechanismArgs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        // ── Positional: server_ident, METHOD, "/path" ─────────────────────
-        let server: Ident = input.parse()?;
-        input.parse::<Token![,]>()?;
-
-        let method: Ident = input.parse()?;
-        input.parse::<Token![,]>()?;
-
-        let path: LitStr = input.parse()?;
-
-        // ── Named (order-independent) keywords ────────────────────────────
-        let mut state: Option<Expr> = None;
-        let mut body_mode = BodyMode::None;
-
-        while input.peek(Token![,]) {
-            input.parse::<Token![,]>()?;
-            if input.is_empty() {
-                break;
-            }
-
-            let kw: Ident = input.parse()?;
-            match kw.to_string().as_str() {
-                "json" => {
-                    if !matches!(body_mode, BodyMode::None) {
-                        return Err(syn::Error::new(
-                            kw.span(),
-                            "#[mechanism]: only one of `json`, `query`, \
-                             `encrypted(…)`, or `encrypted_query(…)` may be \
-                             specified per route",
-                        ));
-                    }
-                    body_mode = BodyMode::Json;
-                }
-                "query" => {
-                    if !matches!(body_mode, BodyMode::None) {
-                        return Err(syn::Error::new(
-                            kw.span(),
-                            "#[mechanism]: only one of `json`, `query`, \
-                             `encrypted(…)`, or `encrypted_query(…)` may be \
-                             specified per route",
-                        ));
-                    }
-                    body_mode = BodyMode::Query;
-                }
-                "state" => {
-                    if state.is_some() {
-                        return Err(syn::Error::new(
-                            kw.span(),
-                            "#[mechanism]: `state(…)` may only be specified once",
-                        ));
-                    }
-                    let content;
-                    syn::parenthesized!(content in input);
-                    state = Some(content.parse::<Expr>()?);
-                }
-                "encrypted" => {
-                    if !matches!(body_mode, BodyMode::None) {
-                        return Err(syn::Error::new(
-                            kw.span(),
-                            "#[mechanism]: only one of `json`, `query`, \
-                             `encrypted(…)`, or `encrypted_query(…)` may be \
-                             specified per route",
-                        ));
-                    }
-                    let content;
-                    syn::parenthesized!(content in input);
-                    body_mode = BodyMode::Encrypted(content.parse::<Expr>()?);
-                }
-                "encrypted_query" => {
-                    if !matches!(body_mode, BodyMode::None) {
-                        return Err(syn::Error::new(
-                            kw.span(),
-                            "#[mechanism]: only one of `json`, `query`, \
-                             `encrypted(…)`, or `encrypted_query(…)` may be \
-                             specified per route",
-                        ));
-                    }
-                    let content;
-                    syn::parenthesized!(content in input);
-                    body_mode = BodyMode::EncryptedQuery(content.parse::<Expr>()?);
-                }
-                other => {
-                    return Err(syn::Error::new(
-                        kw.span(),
-                        format!(
-                            "#[mechanism]: unknown keyword `{other}`. \
-                             Valid keywords: json, query, state(<expr>), \
-                             encrypted(<key>), encrypted_query(<key>)"
-                        ),
-                    ));
-                }
-            }
-        }
-
-        Ok(MechanismArgs { server, method, path, state, body_mode })
-    }
-}
-
-// ─── Helper ───────────────────────────────────────────────────────────────────
-
-#[cfg(feature = "socket-server")]
-/// Extract `(&Pat, &Type)` from a `FnArg::Typed`. Emits a proper error for
-/// `FnArg::Receiver` (i.e. `self`).
-fn extract_pat_ty<'a>(
-    arg: &'a syn::FnArg,
-    position: &str,
-) -> syn::Result<(&'a syn::Pat, &'a syn::Type)> {
-    match arg {
-        syn::FnArg::Typed(pt) => Ok((&pt.pat, &pt.ty)),
-        syn::FnArg::Receiver(r) => Err(syn::Error::new_spanned(
-            &r.self_token,
-            format!(
-                "#[mechanism]: unexpected `self` in the {position} parameter position"
-            ),
-        )),
-    }
-}
-
-// ─── Attribute macro ──────────────────────────────────────────────────────────
-
-#[cfg(feature = "socket-server")]
-/// Concise route declaration for `toolkit-zero` socket-server routes.
+/// Declare a server-side route.
 ///
-/// Replaces an `async fn` item with a `server.mechanism(…)` statement at the
-/// point of declaration. The function body is transplanted verbatim into the
-/// `.onconnect(…)` closure; all variables from the enclosing scope are
-/// accessible via `move` capture.
+/// Available when the `socket-server` feature is enabled.
+/// Re-exported as `toolkit_zero::socket::server::mechanism`.
 ///
-/// # Syntax
-///
-/// ```text
-/// #[mechanism(server, METHOD, "/path")]
-/// #[mechanism(server, METHOD, "/path", json)]
-/// #[mechanism(server, METHOD, "/path", query)]
-/// #[mechanism(server, METHOD, "/path", encrypted(key_expr))]
-/// #[mechanism(server, METHOD, "/path", encrypted_query(key_expr))]
-/// #[mechanism(server, METHOD, "/path", state(state_expr))]
-/// #[mechanism(server, METHOD, "/path", state(state_expr), json)]
-/// #[mechanism(server, METHOD, "/path", state(state_expr), query)]
-/// #[mechanism(server, METHOD, "/path", state(state_expr), encrypted(key_expr))]
-/// #[mechanism(server, METHOD, "/path", state(state_expr), encrypted_query(key_expr))]
-/// ```
-///
-/// The first three arguments (`server`, `METHOD`, `"/path"`) are positional.
-/// `json`, `query`, `state(…)`, `encrypted(…)`, and `encrypted_query(…)` may
-/// appear in any order after the path.
-///
-/// # Parameters
-///
-/// | Argument | Meaning |
-/// |---|---|
-/// | `server` | Identifier of the `Server` variable in the enclosing scope |
-/// | `METHOD` | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS` |
-/// | `"/path"` | Route path string literal |
-/// | `json` | JSON-deserialised body; fn has one param `(body: T)` |
-/// | `query` | URL query params; fn has one param `(params: T)` |
-/// | `encrypted(key)` | VEIL-encrypted body; fn has one param `(body: T)` |
-/// | `encrypted_query(key)` | VEIL-encrypted query; fn has one param `(params: T)` |
-/// | `state(expr)` | State injection; fn first param is `(state: S)` |
-///
-/// When `state` is combined with a body mode the function receives two
-/// parameters: the state clone first, the body or query second.
-///
-/// # Function signature
-///
-/// The decorated function:
-/// - May be `async` or non-async — it is always wrapped in `async move { … }`.
-/// - May carry a return type annotation or none — it is ignored; Rust infers
-///   the return type from the `reply!` macro inside the body.
-/// - Must have exactly the number of parameters described in the table above.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use toolkit_zero::socket::server::{Server, mechanism, reply, Status, SerializationKey};
-/// use serde::{Deserialize, Serialize};
-/// use std::sync::{Arc, Mutex};
-///
-/// #[derive(Deserialize, Serialize, Clone)] struct Item { id: u32, name: String }
-/// #[derive(Deserialize)]                  struct NewItem { name: String }
-/// #[derive(Deserialize)]                  struct Filter { page: u32 }
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let mut server = Server::default();
-///     let db: Arc<Mutex<Vec<Item>>> = Arc::new(Mutex::new(vec![]));
-///
-///     // Plain GET — no body, no state
-///     #[mechanism(server, GET, "/health")]
-///     async fn health() { reply!() }
-///
-///     // POST — JSON body
-///     #[mechanism(server, POST, "/items", json)]
-///     async fn create_item(body: NewItem) {
-///         reply!(json => Item { id: 1, name: body.name }, status => Status::Created)
-///     }
-///
-///     // GET — query params
-///     #[mechanism(server, GET, "/items", query)]
-///     async fn list_items(filter: Filter) {
-///         let _ = filter.page;
-///         reply!()
-///     }
-///
-///     // GET — state + query
-///     #[mechanism(server, GET, "/items/all", state(db.clone()), query)]
-///     async fn list_all(db: Arc<Mutex<Vec<Item>>>, filter: Filter) {
-///         let items = db.lock().unwrap().clone();
-///         reply!(json => items)
-///     }
-///
-///     // POST — state + JSON body
-///     #[mechanism(server, POST, "/items/add", state(db.clone()), json)]
-///     async fn add_item(db: Arc<Mutex<Vec<Item>>>, body: NewItem) {
-///         let id = db.lock().unwrap().len() as u32 + 1;
-///         let item = Item { id, name: body.name };
-///         db.lock().unwrap().push(item.clone());
-///         reply!(json => item, status => Status::Created)
-///     }
-///
-///     // POST — VEIL-encrypted body
-///     #[mechanism(server, POST, "/secure", encrypted(SerializationKey::Default))]
-///     async fn secure_post(body: NewItem) {
-///         reply!(json => Item { id: 99, name: body.name })
-///     }
-///
-///     server.serve(([127, 0, 0, 1], 8080)).await;
-/// }
-/// ```
+/// Full documentation, parameter table, and worked examples are in the
+/// [crate-level `#[mechanism]` section](self#mechanism--server-side-route-declaration).
 #[cfg(feature = "socket-server")]
 #[proc_macro_attribute]
 pub fn mechanism(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as MechanismArgs);
-    let func = parse_macro_input!(item as ItemFn);
-
-    // ── Validate and normalise the HTTP method ────────────────────────────
-    let method_str = args.method.to_string().to_lowercase();
-    let method_ident = Ident::new(&method_str, args.method.span());
-
-    match method_str.as_str() {
-        "get" | "post" | "put" | "delete" | "patch" | "head" | "options" => {}
-        other => {
-            return syn::Error::new(
-                args.method.span(),
-                format!(
-                    "#[mechanism]: `{other}` is not a valid HTTP method. \
-                     Expected GET, POST, PUT, DELETE, PATCH, HEAD, or OPTIONS."
-                ),
-            )
-            .to_compile_error()
-            .into();
-        }
-    }
-
-    let server = &args.server;
-    let path   = &args.path;
-    let body   = &func.block;
-    let params: Vec<&syn::FnArg> = func.sig.inputs.iter().collect();
-
-    // ── Convenience macro: emit a compile error and return ────────────────
-    macro_rules! bail {
-        ($span:expr, $msg:literal) => {{
-            return syn::Error::new($span, $msg)
-                .to_compile_error()
-                .into();
-        }};
-    }
-
-    // ── Build the builder-chain expression ────────────────────────────────
-    let route_expr = match (&args.state, &args.body_mode) {
-
-        // ── Plain ─────────────────────────────────────────────────────────
-        (None, BodyMode::None) => {
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .onconnect(|| async move #body)
-            }
-        }
-
-        // ── JSON body, no state ───────────────────────────────────────────
-        (None, BodyMode::Json) => {
-            if params.is_empty() {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `json` mode requires one function parameter — `(body: YourType)`"
-                );
-            }
-            let (name, ty) = match extract_pat_ty(params[0], "body") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .json::<#ty>()
-                    .onconnect(|#name: #ty| async move #body)
-            }
-        }
-
-        // ── Query params, no state ────────────────────────────────────────
-        (None, BodyMode::Query) => {
-            if params.is_empty() {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `query` mode requires one function parameter — `(params: YourType)`"
-                );
-            }
-            let (name, ty) = match extract_pat_ty(params[0], "query") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .query::<#ty>()
-                    .onconnect(|#name: #ty| async move #body)
-            }
-        }
-
-        // ── VEIL-encrypted body, no state ─────────────────────────────────
-        (None, BodyMode::Encrypted(key_expr)) => {
-            if params.is_empty() {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `encrypted(key)` mode requires one function parameter — `(body: YourType)`"
-                );
-            }
-            let (name, ty) = match extract_pat_ty(params[0], "body") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .encryption::<#ty>(#key_expr)
-                    .onconnect(|#name: #ty| async move #body)
-            }
-        }
-
-        // ── VEIL-encrypted query, no state ────────────────────────────────
-        (None, BodyMode::EncryptedQuery(key_expr)) => {
-            if params.is_empty() {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `encrypted_query(key)` mode requires one function parameter — `(params: YourType)`"
-                );
-            }
-            let (name, ty) = match extract_pat_ty(params[0], "params") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .encrypted_query::<#ty>(#key_expr)
-                    .onconnect(|#name: #ty| async move #body)
-            }
-        }
-
-        // ── State only ────────────────────────────────────────────────────
-        (Some(state_expr), BodyMode::None) => {
-            if params.is_empty() {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `state(expr)` mode requires one function parameter — `(state: YourStateType)`"
-                );
-            }
-            let (name, ty) = match extract_pat_ty(params[0], "state") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .state(#state_expr)
-                    .onconnect(|#name: #ty| async move #body)
-            }
-        }
-
-        // ── State + JSON body ─────────────────────────────────────────────
-        (Some(state_expr), BodyMode::Json) => {
-            if params.len() < 2 {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `state(expr), json` mode requires two function parameters — `(state: S, body: T)`"
-                );
-            }
-            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            let (b_name, b_ty) = match extract_pat_ty(params[1], "body") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .state(#state_expr)
-                    .json::<#b_ty>()
-                    .onconnect(|#s_name: #s_ty, #b_name: #b_ty| async move #body)
-            }
-        }
-
-        // ── State + Query params ──────────────────────────────────────────
-        (Some(state_expr), BodyMode::Query) => {
-            if params.len() < 2 {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `state(expr), query` mode requires two function parameters — `(state: S, params: T)`"
-                );
-            }
-            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            let (q_name, q_ty) = match extract_pat_ty(params[1], "query") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .state(#state_expr)
-                    .query::<#q_ty>()
-                    .onconnect(|#s_name: #s_ty, #q_name: #q_ty| async move #body)
-            }
-        }
-
-        // ── State + VEIL-encrypted body ───────────────────────────────────
-        (Some(state_expr), BodyMode::Encrypted(key_expr)) => {
-            if params.len() < 2 {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `state(expr), encrypted(key)` mode requires two function parameters — `(state: S, body: T)`"
-                );
-            }
-            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            let (b_name, b_ty) = match extract_pat_ty(params[1], "body") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .state(#state_expr)
-                    .encryption::<#b_ty>(#key_expr)
-                    .onconnect(|#s_name: #s_ty, #b_name: #b_ty| async move #body)
-            }
-        }
-
-        // ── State + VEIL-encrypted query ──────────────────────────────────
-        (Some(state_expr), BodyMode::EncryptedQuery(key_expr)) => {
-            if params.len() < 2 {
-                bail!(
-                    func.sig.ident.span(),
-                    "#[mechanism]: `state(expr), encrypted_query(key)` mode requires two function parameters — `(state: S, params: T)`"
-                );
-            }
-            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            let (q_name, q_ty) = match extract_pat_ty(params[1], "query") {
-                Ok(v) => v,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            quote! {
-                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
-                    .state(#state_expr)
-                    .encrypted_query::<#q_ty>(#key_expr)
-                    .onconnect(|#s_name: #s_ty, #q_name: #q_ty| async move #body)
-            }
-        }
-    };
-
-    // ── Final expansion: server.mechanism(<route_expr>); ──────────────────
-    quote! {
-        #server.mechanism(#route_expr);
-    }
-    .into()
+    mechanism::expand(attr, item)
 }
 
-// ─── Client-side: #[request] ─────────────────────────────────────────────────
+// ─── socket-client ────────────────────────────────────────────────────────────
 
-#[cfg(feature = "socket-client")]
-/// Body/query attachment mode for a client request.
-enum RequestBodyMode {
-    None,
-    Json(Expr),
-    Query(Expr),
-    Encrypted(Expr, Expr),
-    EncryptedQuery(Expr, Expr),
-}
-
-#[cfg(feature = "socket-client")]
-/// Whether to call `.send().await?` or `.send_sync()?`.
-enum SendMode {
-    Async,
-    Sync,
-}
-
-#[cfg(feature = "socket-client")]
-/// Fully parsed `#[request]` attribute arguments.
-struct RequestArgs {
-    client: Ident,
-    method: Ident,
-    path:   LitStr,
-    mode:   RequestBodyMode,
-    send:   SendMode,
-}
-
-#[cfg(feature = "socket-client")]
-/// Parse the mandatory final `, async` or `, sync` keyword.
-fn parse_send_mode(input: ParseStream) -> syn::Result<SendMode> {
-    input.parse::<Token![,]>()?;
-    if input.peek(Token![async]) {
-        input.parse::<Token![async]>()?;
-        Ok(SendMode::Async)
-    } else {
-        let kw: Ident = input.parse()?;
-        match kw.to_string().as_str() {
-            "sync" => Ok(SendMode::Sync),
-            _ => Err(syn::Error::new(
-                kw.span(),
-                "#[request]: expected `async` or `sync` as the final argument",
-            )),
-        }
-    }
-}
-
-#[cfg(feature = "socket-client")]
-impl Parse for RequestArgs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        // ── Positional: client_ident, METHOD, "/path" ─────────────────────
-        let client: Ident = input.parse()?;
-        input.parse::<Token![,]>()?;
-
-        let method: Ident = input.parse()?;
-        input.parse::<Token![,]>()?;
-
-        let path: LitStr = input.parse()?;
-        input.parse::<Token![,]>()?;
-
-        // ── Optional mode keyword + mandatory send mode ───────────────────
-        let (mode, send) = if input.peek(Token![async]) {
-            input.parse::<Token![async]>()?;
-            (RequestBodyMode::None, SendMode::Async)
-        } else {
-            let kw: Ident = input.parse()?;
-            match kw.to_string().as_str() {
-                "sync" => (RequestBodyMode::None, SendMode::Sync),
-                "json" => {
-                    let content;
-                    syn::parenthesized!(content in input);
-                    let expr: Expr = content.parse()?;
-                    let send = parse_send_mode(input)?;
-                    (RequestBodyMode::Json(expr), send)
-                }
-                "query" => {
-                    let content;
-                    syn::parenthesized!(content in input);
-                    let expr: Expr = content.parse()?;
-                    let send = parse_send_mode(input)?;
-                    (RequestBodyMode::Query(expr), send)
-                }
-                "encrypted" => {
-                    let content;
-                    syn::parenthesized!(content in input);
-                    let body: Expr = content.parse()?;
-                    content.parse::<Token![,]>()?;
-                    let key: Expr = content.parse()?;
-                    let send = parse_send_mode(input)?;
-                    (RequestBodyMode::Encrypted(body, key), send)
-                }
-                "encrypted_query" => {
-                    let content;
-                    syn::parenthesized!(content in input);
-                    let params: Expr = content.parse()?;
-                    content.parse::<Token![,]>()?;
-                    let key: Expr = content.parse()?;
-                    let send = parse_send_mode(input)?;
-                    (RequestBodyMode::EncryptedQuery(params, key), send)
-                }
-                other => {
-                    return Err(syn::Error::new(
-                        kw.span(),
-                        format!(
-                            "#[request]: unknown keyword `{other}`. \
-                             Valid modes: json(<expr>), query(<expr>), \
-                             encrypted(<body>, <key>), encrypted_query(<params>, <key>). \
-                             Final argument must be `async` or `sync`."
-                        ),
-                    ));
-                }
-            }
-        };
-
-        Ok(RequestArgs { client, method, path, mode, send })
-    }
-}
-
-/// Concise HTTP client request for `toolkit-zero` socket-client routes.
+/// Emit an inline HTTP request and bind the response.
 ///
-/// Replaces a decorated `fn` item with a `let` binding statement that performs
-/// the HTTP request inline.  The function name becomes the binding name; the
-/// return type annotation is used as the response type `R` in `.send::<R>()`.
-/// The function body is discarded entirely.
+/// Available when the `socket-client` feature is enabled.
+/// Re-exported as `toolkit_zero::socket::client::request`.
 ///
-/// # Syntax
-///
-/// ```text
-/// #[request(client, METHOD, "/path", async|sync)]
-/// #[request(client, METHOD, "/path", json(<body_expr>), async|sync)]
-/// #[request(client, METHOD, "/path", query(<params_expr>), async|sync)]
-/// #[request(client, METHOD, "/path", encrypted(<body_expr>, <key_expr>), async|sync)]
-/// #[request(client, METHOD, "/path", encrypted_query(<params_expr>, <key_expr>), async|sync)]
-/// ```
-///
-/// # Parameters
-///
-/// | Argument | Meaning |
-/// |---|---|
-/// | `client` | The [`Client`](toolkit_zero::socket::client::Client) variable in the enclosing scope |
-/// | `METHOD` | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS` |
-/// | `"/path"` | Endpoint path string literal |
-/// | `json(expr)` | Serialise `expr` as a JSON body (`Content-Type: application/json`) |
-/// | `query(expr)` | Serialise `expr` as URL query parameters |
-/// | `encrypted(body, key)` | VEIL-seal `body` with a [`SerializationKey`](toolkit_zero::socket::SerializationKey) |
-/// | `encrypted_query(params, key)` | VEIL-seal `params`, send as `?data=<base64url>` |
-/// | `async` | Finalise with `.send::<R>().await?` |
-/// | `sync`  | Finalise with `.send_sync::<R>()?` |
-///
-/// The function **must** carry an explicit return type — it becomes `R` in the turbofish.
-/// The enclosing function must return a `Result<_, E>` where `E` implements the relevant
-/// `From` for `?` to propagate: `reqwest::Error` for plain/json/query, or
-/// `ClientError` for encrypted variants.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use toolkit_zero::socket::client::{Client, Target, request};
-/// use serde::{Deserialize, Serialize};
-///
-/// #[derive(Deserialize, Serialize, Clone)] struct Item   { id: u32, name: String }
-/// #[derive(Serialize)]                     struct NewItem { name: String }
-/// #[derive(Serialize)]                     struct Filter  { page: u32 }
-///
-/// async fn example() -> Result<(), reqwest::Error> {
-///     let client = Client::new_async(Target::Localhost(8080));
-///
-///     // Plain async GET → let items: Vec<Item> = client.get("/items").send::<Vec<Item>>().await?
-///     #[request(client, GET, "/items", async)]
-///     async fn items() -> Vec<Item> {}
-///
-///     // POST with JSON body
-///     #[request(client, POST, "/items", json(NewItem { name: "widget".into() }), async)]
-///     async fn created() -> Item {}
-///
-///     // GET with query params
-///     #[request(client, GET, "/items", query(Filter { page: 2 }), async)]
-///     async fn page() -> Vec<Item> {}
-///
-///     // Sync DELETE
-///     #[request(client, DELETE, "/items/1", sync)]
-///     fn deleted() -> Item {}
-///
-///     Ok(())
-/// }
-/// ```
+/// Full documentation, parameter table, and worked examples are in the
+/// [crate-level `#[request]` section](self#request--client-side-request-shorthand).
 #[cfg(feature = "socket-client")]
 #[proc_macro_attribute]
 pub fn request(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as RequestArgs);
-    let func = parse_macro_input!(item as ItemFn);
+    request_macro::expand(attr, item)
+}
 
-    // ── Validate HTTP method ──────────────────────────────────────────────
-    let method_str = args.method.to_string().to_lowercase();
-    let method_ident = Ident::new(&method_str, args.method.span());
+// ─── serialization ───────────────────────────────────────────────────────────
 
-    match method_str.as_str() {
-        "get" | "post" | "put" | "delete" | "patch" | "head" | "options" => {}
-        other => {
-            return syn::Error::new(
-                args.method.span(),
-                format!(
-                    "#[request]: `{other}` is not a valid HTTP method. \
-                     Expected GET, POST, PUT, DELETE, PATCH, HEAD, or OPTIONS."
-                ),
-            )
-            .to_compile_error()
-            .into();
-        }
-    }
+/// Derive `bincode::Encode + bincode::Decode` and inject `seal` / `open` methods.
+///
+/// Available when the `serialization` feature is enabled.
+/// Re-exported as `toolkit_zero::serialization::serializable`.
+///
+/// Applies to structs and enums. Named struct fields annotated with
+/// `#[serializable(key = "literal")]` additionally receive `seal_<field>` /
+/// `open_<field>` helpers with the key baked in. Keys are moved in and
+/// wrapped in `Zeroizing<String>`, wiping memory on drop.
+///
+/// Full documentation, expansion details, and examples are in the
+/// [crate-level `#[serializable]` section](self#serializable--derive--inject-sealopen).
+#[cfg(feature = "serialization")]
+#[proc_macro_attribute]
+pub fn serializable(attr: TokenStream, item: TokenStream) -> TokenStream {
+    serialization_macro::expand_serializable(attr, item)
+}
 
-    let client   = &args.client;
-    let path     = &args.path;
-    let var_name = &func.sig.ident;
+/// Emit an inline `seal()` call, binding the result or writing it to a file.
+///
+/// Available when the `serialization` feature is enabled.
+/// Re-exported as `toolkit_zero::serialization::serialize`.
+///
+/// - **Variable mode** — the function name becomes the binding name; the
+///   return type annotation (required) becomes the type of the `let` binding.
+///   The function body is discarded.
+///   ```text
+///   #[serialize(source, key = my_key)]  fn blob() -> Vec<u8> {}
+///   // expands to:  let blob: Vec<u8> = seal(&source, Some(my_key))?;
+///   ```
+///
+/// - **File write mode** — triggered by `path = "..."`. Emits `fs::write(path, seal(…)?)?"`.
+///   The function name and return type are ignored.
+///   ```text
+///   #[serialize(source, path = "out.bin")]  fn _() {}
+///   ```
+///
+/// Full documentation and examples are in the
+/// [crate-level `#[serialize]` section](self#serialize--inline-seal-statement).
+#[cfg(feature = "serialization")]
+#[proc_macro_attribute]
+pub fn serialize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    serialization_macro::expand_serialize(attr, item)
+}
 
-    // ── Return type — required; used as turbofish argument ────────────────
-    let ret_ty = match &func.sig.output {
-        syn::ReturnType::Type(_, ty) => ty.as_ref(),
-        syn::ReturnType::Default => {
-            return syn::Error::new(
-                func.sig.ident.span(),
-                "#[request]: a return type is required — it specifies the response type `R` \
-                 in `.send::<R>()`. Example: `async fn my_var() -> Vec<MyType> {}`",
-            )
-            .to_compile_error()
-            .into();
-        }
-    };
+/// Emit an inline `open()` call, decoding a blob or reading from a file.
+///
+/// Available when the `serialization` feature is enabled.
+/// Re-exported as `toolkit_zero::serialization::deserialize`.
+///
+/// - **Variable mode** — `blob_expr` must be in scope; the function name
+///   becomes the binding name; the return type (required) is used as the
+///   turbofish type `T` in `open::<T>(…)`. The function body is discarded.
+///   ```text
+///   #[deserialize(blob)]  fn config() -> Config {}
+///   // expands to:  let config: Config = open::<Config>(&blob, None)?;
+///   ```
+///
+/// - **File read mode** — triggered by `path = "..."`. Reads the file first,
+///   then passes the bytes to `open::<T>`. Return type still required.
+///   ```text
+///   #[deserialize(path = "config.bin")]  fn config() -> Config {}
+///   ```
+///
+/// Full documentation and examples are in the
+/// [crate-level `#[deserialize]` section](self#deserialize--inline-open-statement).
+#[cfg(feature = "serialization")]
+#[proc_macro_attribute]
+pub fn deserialize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    serialization_macro::expand_deserialize(attr, item)
+}
 
-    // ── Build the partial builder chain (without the send call) ──────────
-    let chain = match &args.mode {
-        RequestBodyMode::None => quote! {
-            #client.#method_ident(#path)
-        },
-        RequestBodyMode::Json(expr) => quote! {
-            #client.#method_ident(#path).json(#expr)
-        },
-        RequestBodyMode::Query(expr) => quote! {
-            #client.#method_ident(#path).query(#expr)
-        },
-        RequestBodyMode::Encrypted(body_expr, key_expr) => quote! {
-            #client.#method_ident(#path).encryption(#body_expr, #key_expr)
-        },
-        RequestBodyMode::EncryptedQuery(params_expr, key_expr) => quote! {
-            #client.#method_ident(#path).encrypted_query(#params_expr, #key_expr)
-        },
-    };
+// ─── location-browser ────────────────────────────────────────────────────────
 
-    // ── Final let-binding statement ───────────────────────────────────────
-    match &args.send {
-        SendMode::Async => quote! {
-            let #var_name: #ret_ty = #chain.send::<#ret_ty>().await?;
-        },
-        SendMode::Sync => quote! {
-            let #var_name: #ret_ty = #chain.send_sync::<#ret_ty>()?;
-        },
-    }
-    .into()
+#[cfg(feature = "location-browser")]
+mod browser_macro;
+
+/// Replace a decorated `fn` with an inline location-capture statement.
+///
+/// Available when the `location` (or `location-browser`) feature is enabled.
+/// Re-exported as `toolkit_zero::location::browser`.
+///
+/// The macro wraps either [`__location__`] (with `sync`) or
+/// [`__location_async__`] (default) and builds the [`PageTemplate`] for you.
+///
+/// [`__location__`]: toolkit_zero::location::browser::__location__
+/// [`__location_async__`]: toolkit_zero::location::browser::__location_async__
+/// [`PageTemplate`]: toolkit_zero::location::browser::PageTemplate
+///
+/// ## Syntax
+///
+/// ```text
+/// #[browser]                                        // async, Default template
+/// #[browser(sync)]                                  // blocking, Default template
+/// #[browser(title = "My App")]                      // async, custom title
+/// #[browser(title = "T", body = "B")]               // async, title + body
+/// #[browser(tickbox)]                               // async, Tickbox template
+/// #[browser(tickbox, title = "T", consent = "C")]   // async, Tickbox with args
+/// #[browser(html = "<html>…</html>")]               // async, Custom template
+/// #[browser(sync, title = "T")]                     // sync + any variant
+/// ```
+///
+/// All arguments are optional and may appear in **any order**.
+///
+/// ## Arguments
+///
+/// | Argument | Type | Notes |
+/// |---|---|---|
+/// | `sync` | flag | Use the blocking `__location__` function; default uses `__location_async__().await` |
+/// | `tickbox` | flag | Use `PageTemplate::Tickbox`; default is `PageTemplate::Default` |
+/// | `title = "…"` | string literal | Sets the `title` field on Default or Tickbox |
+/// | `body = "…"` | string literal | Sets the `body_text` field on Default or Tickbox |
+/// | `consent = "…"` | string literal | Sets the `consent_text` field on Tickbox only |
+/// | `html = "…"` | string literal | Use `PageTemplate::Custom`; **mutually exclusive** with tickbox/title/body/consent |
+///
+/// ## What the macro expands to
+///
+/// The function's **name** becomes the binding; the body is discarded.
+/// A `?` propagates any [`LocationError`](toolkit_zero::location::browser::LocationError).
+///
+/// ```rust,ignore
+/// // Input:
+/// #[browser(title = "My App")]
+/// fn loc() -> LocationData {}
+///
+/// // Expanded to:
+/// let loc = ::toolkit_zero::location::browser::__location_async__(
+///     ::toolkit_zero::location::browser::PageTemplate::Default {
+///         title:     ::std::option::Option::Some("My App".to_string()),
+///         body_text: ::std::option::Option::None,
+///     }
+/// ).await?;
+/// ```
+///
+/// Full documentation and examples are in the
+/// [crate-level `#[browser]` section](self#browser--inline-location-capture).
+#[cfg(feature = "location-browser")]
+#[proc_macro_attribute]
+pub fn browser(attr: TokenStream, item: TokenStream) -> TokenStream {
+    browser_macro::expand_browser(attr, item)
+}
+
+// ─── enc-timelock-* ──────────────────────────────────────────────────────────
+
+#[cfg(any(
+    feature = "enc-timelock-keygen-now",
+    feature = "enc-timelock-keygen-input",
+    feature = "enc-timelock-async-keygen-now",
+    feature = "enc-timelock-async-keygen-input",
+))]
+mod timelock_macro;
+
+#[cfg(feature = "dep-graph-capture")]
+mod dependencies_macro;
+
+/// Replace a decorated `fn` with an inline time-locked key derivation call.
+///
+/// Available when any `enc-timelock-*` feature is enabled.
+/// Re-exported as `toolkit_zero::encryption::timelock::timelock` (the macro).
+///
+/// Routes to either [`timelock`] (sync) or [`timelock_async`] (async — add
+/// the `async` flag) and builds the positional `Option<…>` arguments for you.
+///
+/// [`timelock`]: toolkit_zero::encryption::timelock::timelock
+/// [`timelock_async`]: toolkit_zero::encryption::timelock::timelock_async
+///
+/// ## Two paths
+///
+/// | Path | When to use | Required args |
+/// |---|---|---|
+/// | **Encryption** | Generate a key from an explicit time | `precision`, `format`, `time`, `salts`, `kdf` |
+/// | **Decryption** | Re-derive a key from a stored header | `params` |
+///
+/// ## Syntax
+///
+/// ```text
+/// // Encryption path
+/// #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+/// #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k,
+///            cadence = DayOfWeek(Tuesday))]
+/// #[timelock(async, precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+///
+/// // Decryption path
+/// #[timelock(params = header)]
+/// #[timelock(async, params = header)]
+/// ```
+///
+/// ## Arguments
+///
+/// | Argument | Type | Notes |
+/// |---|---|---|
+/// | `async` | flag | Use `timelock_async().await?`; default uses `timelock()?` |
+/// | `params = expr` | [`TimeLockParams`] | **Decryption path**. Mutually exclusive with all other args |
+/// | `precision = …` | `Hour` \| `Quarter` \| `Minute` | Encryption path. Time quantisation level |
+/// | `format = …` | `Hour12` \| `Hour24` | Encryption path. Clock representation |
+/// | `time(h, m)` | two int literals | Encryption path. Target time (24-hour `h`, `m`) |
+/// | `cadence = …` | variant or `None` | Optional; defaults to `None` (`TimeLockCadence::None`) |
+/// | `salts = expr` | [`TimeLockSalts`] | Encryption path. Three 32-byte KDF salts |
+/// | `kdf = expr` | [`KdfParams`] | Encryption path. KDF work-factor parameters |
+///
+/// [`TimeLockParams`]: toolkit_zero::encryption::timelock::TimeLockParams
+/// [`TimeLockSalts`]:  toolkit_zero::encryption::timelock::TimeLockSalts
+/// [`KdfParams`]:      toolkit_zero::encryption::timelock::KdfParams
+///
+/// ## Cadence variants
+///
+/// ```text
+/// cadence = None
+/// cadence = DayOfWeek(Tuesday)
+/// cadence = DayOfMonth(15)
+/// cadence = MonthOfYear(January)
+/// cadence = DayOfWeekInMonth(Tuesday, January)
+/// cadence = DayOfMonthInMonth(15, January)
+/// cadence = DayOfWeekAndDayOfMonth(Tuesday, 15)
+/// ```
+///
+/// ## What the macro expands to
+///
+/// ```rust,ignore
+/// // Encryption path:
+/// #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+/// fn enc_key() {}
+/// // expands to:
+/// // let enc_key = ::toolkit_zero::encryption::timelock::timelock(
+/// //     Some(TimeLockCadence::None),
+/// //     Some(TimeLockTime::new(14, 37).unwrap()),
+/// //     Some(TimePrecision::Minute),
+/// //     Some(TimeFormat::Hour24),
+/// //     Some(s), Some(k), None,
+/// // )?;
+///
+/// // Decryption path:
+/// #[timelock(params = header)]
+/// fn dec_key() {}
+/// // expands to:
+/// // let dec_key = ::toolkit_zero::encryption::timelock::timelock(
+/// //     None, None, None, None, None, None,
+/// //     Some(header),
+/// // )?;
+/// ```
+///
+/// Full documentation and examples are in the
+/// [crate-level `#[timelock]` section](self#timelock--inline-key-derivation).
+#[cfg(any(
+    feature = "enc-timelock-keygen-now",
+    feature = "enc-timelock-keygen-input",
+    feature = "enc-timelock-async-keygen-now",
+    feature = "enc-timelock-async-keygen-input",
+))]
+#[proc_macro_attribute]
+pub fn timelock(attr: TokenStream, item: TokenStream) -> TokenStream {
+    timelock_macro::expand_timelock(attr, item)
+}
+
+// ─── #[dependencies] ──────────────────────────────────────────────────────────
+
+/// Embed and parse (or read the raw bytes of) the build-time
+/// `fingerprint.json` fingerprint in one expression.
+///
+/// Apply to an empty `fn`; the function name becomes the `let` binding in
+/// the expansion. Requires the `dependency-graph-capture` feature.
+///
+/// ## Parse mode (default)
+///
+/// ```rust,ignore
+/// use toolkit_zero::dependency_graph::capture::{dependencies, BuildTimeFingerprintData};
+///
+/// fn show() -> Result<(), Box<dyn std::error::Error>> {
+///     #[dependencies]
+///     fn data() {}
+///     // expands to:
+///     // const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+///     //     include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+///     // let data = capture::parse(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__)?;
+///
+///     println!("{} v{}", data.package.name, data.package.version);
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Bytes mode
+///
+/// ```rust,ignore
+/// fn raw_bytes() -> &'static [u8] {
+///     #[dependencies(bytes)]
+///     fn raw() {}
+///     // expands to:
+///     // const __TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__: &str =
+///     //     include_str!(concat!(env!("OUT_DIR"), "/fingerprint.json"));
+///     // let raw: &'static [u8] = capture::as_bytes(__TOOLKIT_ZERO_BUILD_TIME_FINGERPRINT__);
+///     raw
+/// }
+/// ```
+///
+/// Full documentation is in the
+/// [crate-level `#[dependencies]` section](self#dependencies--build-time-fingerprint-capture).
+#[cfg(feature = "dep-graph-capture")]
+#[proc_macro_attribute]
+pub fn dependencies(attr: TokenStream, item: TokenStream) -> TokenStream {
+    dependencies_macro::expand_dependencies(attr, item)
 }

--- a/toolkit-zero-macros/src/mechanism.rs
+++ b/toolkit-zero-macros/src/mechanism.rs
@@ -1,0 +1,400 @@
+// ─── socket-server: #[mechanism] ────────────────────────────────────────────
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Expr, Ident, ItemFn, LitStr, Token,
+};
+
+// ─── Argument types ───────────────────────────────────────────────────────────
+
+/// The body/query mode keyword extracted from the attribute arguments.
+enum BodyMode {
+    None,
+    Json,
+    Query,
+    Encrypted(Expr),
+    EncryptedQuery(Expr),
+}
+
+/// Fully parsed attribute arguments.
+struct MechanismArgs {
+    /// The `Server` variable identifier in the enclosing scope.
+    server: Ident,
+    /// HTTP method identifier (GET, POST, …).
+    method: Ident,
+    /// Route path string literal.
+    path: LitStr,
+    /// Optional `state(expr)` argument.
+    state: Option<Expr>,
+    /// How the request body / query is processed.
+    body_mode: BodyMode,
+}
+
+impl Parse for MechanismArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // ── Positional: server_ident, METHOD, "/path" ─────────────────────
+        let server: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let method: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let path: LitStr = input.parse()?;
+
+        // ── Named (order-independent) keywords ────────────────────────────
+        let mut state: Option<Expr> = None;
+        let mut body_mode = BodyMode::None;
+
+        while input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+
+            let kw: Ident = input.parse()?;
+            match kw.to_string().as_str() {
+                "json" => {
+                    if !matches!(body_mode, BodyMode::None) {
+                        return Err(syn::Error::new(
+                            kw.span(),
+                            "#[mechanism]: only one of `json`, `query`, \
+                             `encrypted(…)`, or `encrypted_query(…)` may be \
+                             specified per route",
+                        ));
+                    }
+                    body_mode = BodyMode::Json;
+                }
+                "query" => {
+                    if !matches!(body_mode, BodyMode::None) {
+                        return Err(syn::Error::new(
+                            kw.span(),
+                            "#[mechanism]: only one of `json`, `query`, \
+                             `encrypted(…)`, or `encrypted_query(…)` may be \
+                             specified per route",
+                        ));
+                    }
+                    body_mode = BodyMode::Query;
+                }
+                "state" => {
+                    if state.is_some() {
+                        return Err(syn::Error::new(
+                            kw.span(),
+                            "#[mechanism]: `state(…)` may only be specified once",
+                        ));
+                    }
+                    let content;
+                    syn::parenthesized!(content in input);
+                    state = Some(content.parse::<Expr>()?);
+                }
+                "encrypted" => {
+                    if !matches!(body_mode, BodyMode::None) {
+                        return Err(syn::Error::new(
+                            kw.span(),
+                            "#[mechanism]: only one of `json`, `query`, \
+                             `encrypted(…)`, or `encrypted_query(…)` may be \
+                             specified per route",
+                        ));
+                    }
+                    let content;
+                    syn::parenthesized!(content in input);
+                    body_mode = BodyMode::Encrypted(content.parse::<Expr>()?);
+                }
+                "encrypted_query" => {
+                    if !matches!(body_mode, BodyMode::None) {
+                        return Err(syn::Error::new(
+                            kw.span(),
+                            "#[mechanism]: only one of `json`, `query`, \
+                             `encrypted(…)`, or `encrypted_query(…)` may be \
+                             specified per route",
+                        ));
+                    }
+                    let content;
+                    syn::parenthesized!(content in input);
+                    body_mode = BodyMode::EncryptedQuery(content.parse::<Expr>()?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        kw.span(),
+                        format!(
+                            "#[mechanism]: unknown keyword `{other}`. \
+                             Valid keywords: json, query, state(<expr>), \
+                             encrypted(<key>), encrypted_query(<key>)"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(MechanismArgs { server, method, path, state, body_mode })
+    }
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+/// Extract `(&Pat, &Type)` from a `FnArg::Typed`. Emits a proper error for
+/// `FnArg::Receiver` (i.e. `self`).
+fn extract_pat_ty<'a>(
+    arg: &'a syn::FnArg,
+    position: &str,
+) -> syn::Result<(&'a syn::Pat, &'a syn::Type)> {
+    match arg {
+        syn::FnArg::Typed(pt) => Ok((&pt.pat, &pt.ty)),
+        syn::FnArg::Receiver(r) => Err(syn::Error::new_spanned(
+            &r.self_token,
+            format!(
+                "#[mechanism]: unexpected `self` in the {position} parameter position"
+            ),
+        )),
+    }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as MechanismArgs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    // ── Validate and normalise the HTTP method ────────────────────────────
+    let method_str = args.method.to_string().to_lowercase();
+    let method_ident = Ident::new(&method_str, args.method.span());
+
+    match method_str.as_str() {
+        "get" | "post" | "put" | "delete" | "patch" | "head" | "options" => {}
+        other => {
+            return syn::Error::new(
+                args.method.span(),
+                format!(
+                    "#[mechanism]: `{other}` is not a valid HTTP method. \
+                     Expected GET, POST, PUT, DELETE, PATCH, HEAD, or OPTIONS."
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    let server = &args.server;
+    let path   = &args.path;
+    let body   = &func.block;
+    let params: Vec<&syn::FnArg> = func.sig.inputs.iter().collect();
+
+    // ── Convenience macro: emit a compile error and return ────────────────
+    macro_rules! bail {
+        ($span:expr, $msg:literal) => {{
+            return syn::Error::new($span, $msg)
+                .to_compile_error()
+                .into();
+        }};
+    }
+
+    // ── Build the builder-chain expression ────────────────────────────────
+    let route_expr = match (&args.state, &args.body_mode) {
+
+        // ── Plain ─────────────────────────────────────────────────────────
+        (None, BodyMode::None) => {
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .onconnect(|| async move #body)
+            }
+        }
+
+        // ── JSON body, no state ───────────────────────────────────────────
+        (None, BodyMode::Json) => {
+            if params.is_empty() {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `json` mode requires one function parameter — `(body: YourType)`"
+                );
+            }
+            let (name, ty) = match extract_pat_ty(params[0], "body") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .json::<#ty>()
+                    .onconnect(|#name: #ty| async move #body)
+            }
+        }
+
+        // ── Query params, no state ────────────────────────────────────────
+        (None, BodyMode::Query) => {
+            if params.is_empty() {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `query` mode requires one function parameter — `(params: YourType)`"
+                );
+            }
+            let (name, ty) = match extract_pat_ty(params[0], "query") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .query::<#ty>()
+                    .onconnect(|#name: #ty| async move #body)
+            }
+        }
+
+        // ── VEIL-encrypted body, no state ─────────────────────────────────
+        (None, BodyMode::Encrypted(key_expr)) => {
+            if params.is_empty() {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `encrypted(key)` mode requires one function parameter — `(body: YourType)`"
+                );
+            }
+            let (name, ty) = match extract_pat_ty(params[0], "body") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .encryption::<#ty>(#key_expr)
+                    .onconnect(|#name: #ty| async move #body)
+            }
+        }
+
+        // ── VEIL-encrypted query, no state ────────────────────────────────
+        (None, BodyMode::EncryptedQuery(key_expr)) => {
+            if params.is_empty() {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `encrypted_query(key)` mode requires one function parameter — `(params: YourType)`"
+                );
+            }
+            let (name, ty) = match extract_pat_ty(params[0], "params") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .encrypted_query::<#ty>(#key_expr)
+                    .onconnect(|#name: #ty| async move #body)
+            }
+        }
+
+        // ── State only ────────────────────────────────────────────────────
+        (Some(state_expr), BodyMode::None) => {
+            if params.is_empty() {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `state(expr)` mode requires one function parameter — `(state: YourStateType)`"
+                );
+            }
+            let (name, ty) = match extract_pat_ty(params[0], "state") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .state(#state_expr)
+                    .onconnect(|#name: #ty| async move #body)
+            }
+        }
+
+        // ── State + JSON body ─────────────────────────────────────────────
+        (Some(state_expr), BodyMode::Json) => {
+            if params.len() < 2 {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `state(expr), json` mode requires two function parameters — `(state: S, body: T)`"
+                );
+            }
+            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            let (b_name, b_ty) = match extract_pat_ty(params[1], "body") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .state(#state_expr)
+                    .json::<#b_ty>()
+                    .onconnect(|#s_name: #s_ty, #b_name: #b_ty| async move #body)
+            }
+        }
+
+        // ── State + Query params ──────────────────────────────────────────
+        (Some(state_expr), BodyMode::Query) => {
+            if params.len() < 2 {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `state(expr), query` mode requires two function parameters — `(state: S, params: T)`"
+                );
+            }
+            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            let (q_name, q_ty) = match extract_pat_ty(params[1], "query") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .state(#state_expr)
+                    .query::<#q_ty>()
+                    .onconnect(|#s_name: #s_ty, #q_name: #q_ty| async move #body)
+            }
+        }
+
+        // ── State + VEIL-encrypted body ───────────────────────────────────
+        (Some(state_expr), BodyMode::Encrypted(key_expr)) => {
+            if params.len() < 2 {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `state(expr), encrypted(key)` mode requires two function parameters — `(state: S, body: T)`"
+                );
+            }
+            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            let (b_name, b_ty) = match extract_pat_ty(params[1], "body") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .state(#state_expr)
+                    .encryption::<#b_ty>(#key_expr)
+                    .onconnect(|#s_name: #s_ty, #b_name: #b_ty| async move #body)
+            }
+        }
+
+        // ── State + VEIL-encrypted query ──────────────────────────────────
+        (Some(state_expr), BodyMode::EncryptedQuery(key_expr)) => {
+            if params.len() < 2 {
+                bail!(
+                    func.sig.ident.span(),
+                    "#[mechanism]: `state(expr), encrypted_query(key)` mode requires two function parameters — `(state: S, params: T)`"
+                );
+            }
+            let (s_name, s_ty) = match extract_pat_ty(params[0], "state") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            let (q_name, q_ty) = match extract_pat_ty(params[1], "query") {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            quote! {
+                toolkit_zero::socket::server::ServerMechanism::#method_ident(#path)
+                    .state(#state_expr)
+                    .encrypted_query::<#q_ty>(#key_expr)
+                    .onconnect(|#s_name: #s_ty, #q_name: #q_ty| async move #body)
+            }
+        }
+    };
+
+    // ── Final expansion: server.mechanism(<route_expr>); ──────────────────
+    quote! {
+        #server.mechanism(#route_expr);
+    }
+    .into()
+}

--- a/toolkit-zero-macros/src/request_macro.rs
+++ b/toolkit-zero-macros/src/request_macro.rs
@@ -1,0 +1,196 @@
+// ─── socket-client: #[request] ───────────────────────────────────────────────
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Expr, Ident, ItemFn, LitStr, Token,
+};
+
+// ─── Argument types ───────────────────────────────────────────────────────────
+
+/// Body/query attachment mode for a client request.
+enum RequestBodyMode {
+    None,
+    Json(Expr),
+    Query(Expr),
+    Encrypted(Expr, Expr),
+    EncryptedQuery(Expr, Expr),
+}
+
+/// Whether to call `.send().await?` or `.send_sync()?`.
+enum SendMode {
+    Async,
+    Sync,
+}
+
+/// Fully parsed `#[request]` attribute arguments.
+struct RequestArgs {
+    client: Ident,
+    method: Ident,
+    path:   LitStr,
+    mode:   RequestBodyMode,
+    send:   SendMode,
+}
+
+/// Parse the mandatory final `, async` or `, sync` keyword.
+fn parse_send_mode(input: ParseStream) -> syn::Result<SendMode> {
+    input.parse::<Token![,]>()?;
+    if input.peek(Token![async]) {
+        input.parse::<Token![async]>()?;
+        Ok(SendMode::Async)
+    } else {
+        let kw: Ident = input.parse()?;
+        match kw.to_string().as_str() {
+            "sync" => Ok(SendMode::Sync),
+            _ => Err(syn::Error::new(
+                kw.span(),
+                "#[request]: expected `async` or `sync` as the final argument",
+            )),
+        }
+    }
+}
+
+impl Parse for RequestArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // ── Positional: client_ident, METHOD, "/path" ─────────────────────
+        let client: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let method: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let path: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        // ── Optional mode keyword + mandatory send mode ───────────────────
+        let (mode, send) = if input.peek(Token![async]) {
+            input.parse::<Token![async]>()?;
+            (RequestBodyMode::None, SendMode::Async)
+        } else {
+            let kw: Ident = input.parse()?;
+            match kw.to_string().as_str() {
+                "sync" => (RequestBodyMode::None, SendMode::Sync),
+                "json" => {
+                    let content;
+                    syn::parenthesized!(content in input);
+                    let expr: Expr = content.parse()?;
+                    let send = parse_send_mode(input)?;
+                    (RequestBodyMode::Json(expr), send)
+                }
+                "query" => {
+                    let content;
+                    syn::parenthesized!(content in input);
+                    let expr: Expr = content.parse()?;
+                    let send = parse_send_mode(input)?;
+                    (RequestBodyMode::Query(expr), send)
+                }
+                "encrypted" => {
+                    let content;
+                    syn::parenthesized!(content in input);
+                    let body: Expr = content.parse()?;
+                    content.parse::<Token![,]>()?;
+                    let key: Expr = content.parse()?;
+                    let send = parse_send_mode(input)?;
+                    (RequestBodyMode::Encrypted(body, key), send)
+                }
+                "encrypted_query" => {
+                    let content;
+                    syn::parenthesized!(content in input);
+                    let params: Expr = content.parse()?;
+                    content.parse::<Token![,]>()?;
+                    let key: Expr = content.parse()?;
+                    let send = parse_send_mode(input)?;
+                    (RequestBodyMode::EncryptedQuery(params, key), send)
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        kw.span(),
+                        format!(
+                            "#[request]: unknown keyword `{other}`. \
+                             Valid modes: json(<expr>), query(<expr>), \
+                             encrypted(<body>, <key>), encrypted_query(<params>, <key>). \
+                             Final argument must be `async` or `sync`."
+                        ),
+                    ));
+                }
+            }
+        };
+
+        Ok(RequestArgs { client, method, path, mode, send })
+    }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as RequestArgs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    // ── Validate HTTP method ──────────────────────────────────────────────
+    let method_str = args.method.to_string().to_lowercase();
+    let method_ident = Ident::new(&method_str, args.method.span());
+
+    match method_str.as_str() {
+        "get" | "post" | "put" | "delete" | "patch" | "head" | "options" => {}
+        other => {
+            return syn::Error::new(
+                args.method.span(),
+                format!(
+                    "#[request]: `{other}` is not a valid HTTP method. \
+                     Expected GET, POST, PUT, DELETE, PATCH, HEAD, or OPTIONS."
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    let client   = &args.client;
+    let path     = &args.path;
+    let var_name = &func.sig.ident;
+
+    // ── Return type — required; used as turbofish argument ────────────────
+    let ret_ty = match &func.sig.output {
+        syn::ReturnType::Type(_, ty) => ty.as_ref(),
+        syn::ReturnType::Default => {
+            return syn::Error::new(
+                func.sig.ident.span(),
+                "#[request]: a return type is required — it specifies the response type `R` \
+                 in `.send::<R>()`. Example: `async fn my_var() -> Vec<MyType> {}`",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    // ── Build the partial builder chain (without the send call) ──────────
+    let chain = match &args.mode {
+        RequestBodyMode::None => quote! {
+            #client.#method_ident(#path)
+        },
+        RequestBodyMode::Json(expr) => quote! {
+            #client.#method_ident(#path).json(#expr)
+        },
+        RequestBodyMode::Query(expr) => quote! {
+            #client.#method_ident(#path).query(#expr)
+        },
+        RequestBodyMode::Encrypted(body_expr, key_expr) => quote! {
+            #client.#method_ident(#path).encryption(#body_expr, #key_expr)
+        },
+        RequestBodyMode::EncryptedQuery(params_expr, key_expr) => quote! {
+            #client.#method_ident(#path).encrypted_query(#params_expr, #key_expr)
+        },
+    };
+
+    // ── Final let-binding statement ───────────────────────────────────────
+    match &args.send {
+        SendMode::Async => quote! {
+            let #var_name: #ret_ty = #chain.send::<#ret_ty>().await?;
+        },
+        SendMode::Sync => quote! {
+            let #var_name: #ret_ty = #chain.send_sync::<#ret_ty>()?;
+        },
+    }
+    .into()
+}

--- a/toolkit-zero-macros/src/serialization_macro.rs
+++ b/toolkit-zero-macros/src/serialization_macro.rs
@@ -1,0 +1,341 @@
+// ─── serialization macros ─────────────────────────────────────────────────────
+//
+// #[serializable]  — derives Encode+Decode and injects seal/open methods
+// #[serialize]     — inline seal to variable or file
+// #[deserialize]   — inline open from variable or file
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Data, DeriveInput, Expr, Fields, Ident, ItemFn, LitStr, Token,
+};
+
+// ─── #[serializable] ─────────────────────────────────────────────────────────
+
+pub fn expand_serializable(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let _ = attr; // struct-level: no attribute args expected
+
+    let mut input = parse_macro_input!(item as DeriveInput);
+
+    let name = input.ident.clone();
+
+    // Serialise generics to TokenStream2 early so we can later move `input`.
+    let (impl_generics_ts, ty_generics_ts, where_clause_ts) = {
+        let (i, t, w) = input.generics.split_for_impl();
+        (quote!(#i), quote!(#t), quote!(#w))
+    };
+
+    let mut per_field_methods: Vec<TokenStream2> = vec![];
+
+    // ── Process struct fields: strip helper #[serializable(key = "...")] ──
+    if let Data::Struct(ref mut ds) = input.data {
+        let fields_opt = match &mut ds.fields {
+            Fields::Named(f)   => Some(&mut f.named),
+            Fields::Unnamed(f) => Some(&mut f.unnamed),
+            Fields::Unit       => None,
+        };
+
+        if let Some(fields) = fields_opt {
+            for field in fields.iter_mut() {
+                let field_name = match &field.ident {
+                    Some(id) => id.clone(),
+                    None     => continue, // unnamed fields don't get per-field helpers
+                };
+                let field_ty = field.ty.clone();
+
+                let mut found_key: Option<LitStr> = None;
+
+                // Strip #[serializable(key = "...")] and remember the key
+                field.attrs.retain(|a| {
+                    if a.path().is_ident("serializable") {
+                        if let Ok(lit) = a.parse_args_with(|inp: ParseStream| {
+                            let kw: Ident = inp.parse()?;
+                            if kw != "key" {
+                                return Err(syn::Error::new(
+                                    kw.span(),
+                                    "#[serializable]: field attribute syntax is \
+                                     `#[serializable(key = \"your-key\")]`",
+                                ));
+                            }
+                            inp.parse::<Token![=]>()?;
+                            inp.parse::<LitStr>()
+                        }) {
+                            found_key = Some(lit);
+                        }
+                        false // remove the attr from field
+                    } else {
+                        true
+                    }
+                });
+
+                if let Some(key_lit) = found_key {
+                    let seal_fn = format_ident!("seal_{}", field_name);
+                    let open_fn = format_ident!("open_{}", field_name);
+
+                    per_field_methods.push(quote! {
+                        /// Seal the `#field_name` field with its associated key.
+                        pub fn #seal_fn(
+                            &self,
+                        ) -> ::std::result::Result<
+                            ::std::vec::Vec<u8>,
+                            ::toolkit_zero::serialization::SerializationError,
+                        > {
+                            ::toolkit_zero::serialization::seal(
+                                &self.#field_name,
+                                ::std::option::Option::Some(#key_lit.to_string()),
+                            )
+                        }
+
+                        /// Open a blob sealed by `seal_#field_name`.
+                        pub fn #open_fn(
+                            bytes: &[u8],
+                        ) -> ::std::result::Result<
+                            #field_ty,
+                            ::toolkit_zero::serialization::SerializationError,
+                        > {
+                            ::toolkit_zero::serialization::open::<#field_ty>(
+                                bytes,
+                                ::std::option::Option::Some(#key_lit.to_string()),
+                            )
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    quote! {
+        #[derive(
+            ::toolkit_zero::serialization::Encode,
+            ::toolkit_zero::serialization::Decode,
+        )]
+        #[bincode(crate = "::toolkit_zero::serialization::bincode")]
+        #input
+
+        impl #impl_generics_ts #name #ty_generics_ts #where_clause_ts {
+            /// Encode and seal this value into an encrypted byte blob.
+            ///
+            /// Pass `None` to use the default VEIL key, or `Some(key)` for a
+            /// custom key.  The key is moved in and zeroized on drop.
+            pub fn seal(
+                &self,
+                key: ::std::option::Option<::std::string::String>,
+            ) -> ::std::result::Result<
+                ::std::vec::Vec<u8>,
+                ::toolkit_zero::serialization::SerializationError,
+            > {
+                ::toolkit_zero::serialization::seal(self, key)
+            }
+
+            /// Open a byte blob produced by [`seal`] back into `Self`.
+            ///
+            /// Pass the same key that was used in [`seal`], or `None` for the
+            /// default key.  The key is moved in and zeroized on drop.
+            pub fn open(
+                bytes: &[u8],
+                key: ::std::option::Option<::std::string::String>,
+            ) -> ::std::result::Result<
+                Self,
+                ::toolkit_zero::serialization::SerializationError,
+            > {
+                ::toolkit_zero::serialization::open::<Self>(bytes, key)
+            }
+
+            #(#per_field_methods)*
+        }
+    }
+    .into()
+}
+
+// ─── #[serialize] ────────────────────────────────────────────────────────────
+
+struct SerializeArgs {
+    /// The expression to seal (e.g. `my_struct`).
+    source: Expr,
+    /// Present → file write mode; absent → variable binding mode.
+    path: Option<LitStr>,
+    /// Optional explicit key expression.
+    key: Option<Expr>,
+}
+
+impl Parse for SerializeArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let source: Expr = input.parse()?;
+
+        let mut path: Option<LitStr> = None;
+        let mut key: Option<Expr> = None;
+
+        while input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+
+            let kw: Ident = input.parse()?;
+            match kw.to_string().as_str() {
+                "path" => {
+                    input.parse::<Token![=]>()?;
+                    path = Some(input.parse::<LitStr>()?);
+                }
+                "key" => {
+                    input.parse::<Token![=]>()?;
+                    key = Some(input.parse::<Expr>()?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        kw.span(),
+                        format!(
+                            "#[serialize]: unknown keyword `{other}`. \
+                             Valid keywords: path = \"file.bin\", key = <expr>"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(SerializeArgs { source, path, key })
+    }
+}
+
+pub fn expand_serialize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as SerializeArgs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    let key_arg = match &args.key {
+        Some(k) => quote! { ::std::option::Option::Some(#k) },
+        None    => quote! { ::std::option::Option::None },
+    };
+
+    let source = &args.source;
+
+    match &args.path {
+        // ── File write mode ───────────────────────────────────────────────
+        Some(path_lit) => quote! {
+            ::std::fs::write(
+                #path_lit,
+                ::toolkit_zero::serialization::seal(&#source, #key_arg)?,
+            )?;
+        },
+
+        // ── Variable binding mode ─────────────────────────────────────────
+        None => {
+            let var_name = &func.sig.ident;
+
+            let ret_ty = match &func.sig.output {
+                syn::ReturnType::Type(_, ty) => ty.as_ref(),
+                syn::ReturnType::Default => {
+                    return syn::Error::new(
+                        func.sig.ident.span(),
+                        "#[serialize]: a return type is required in variable mode. \
+                         Example: `fn blob() -> Vec<u8> {}`",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+            };
+
+            quote! {
+                let #var_name: #ret_ty =
+                    ::toolkit_zero::serialization::seal(&#source, #key_arg)?;
+            }
+        }
+    }
+    .into()
+}
+
+// ─── #[deserialize] ──────────────────────────────────────────────────────────
+
+enum DeserializeSource {
+    Blob(Expr),
+    Path(LitStr),
+}
+
+struct DeserializeArgs {
+    source: DeserializeSource,
+    key: Option<Expr>,
+}
+
+impl Parse for DeserializeArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Detect `path = "..."` vs a blob expression
+        let source = if input.peek(Ident) {
+            let fork = input.fork();
+            let kw: Ident = fork.parse()?;
+            if kw == "path" && fork.peek(Token![=]) {
+                input.parse::<Ident>()?; // consume "path"
+                input.parse::<Token![=]>()?;
+                DeserializeSource::Path(input.parse::<LitStr>()?)
+            } else {
+                DeserializeSource::Blob(input.parse::<Expr>()?)
+            }
+        } else {
+            DeserializeSource::Blob(input.parse::<Expr>()?)
+        };
+
+        let mut key: Option<Expr> = None;
+
+        while input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+
+            let kw: Ident = input.parse()?;
+            match kw.to_string().as_str() {
+                "key" => {
+                    input.parse::<Token![=]>()?;
+                    key = Some(input.parse::<Expr>()?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        kw.span(),
+                        format!(
+                            "#[deserialize]: unknown keyword `{other}`. \
+                             Valid keywords: key = <expr>"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(DeserializeArgs { source, key })
+    }
+}
+
+pub fn expand_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as DeserializeArgs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    let var_name = &func.sig.ident;
+
+    let ret_ty = match &func.sig.output {
+        syn::ReturnType::Type(_, ty) => ty.as_ref(),
+        syn::ReturnType::Default => {
+            return syn::Error::new(
+                func.sig.ident.span(),
+                "#[deserialize]: a return type is required. \
+                 Example: `fn config() -> MyStruct {}`",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let key_arg = match &args.key {
+        Some(k) => quote! { ::std::option::Option::Some(#k) },
+        None    => quote! { ::std::option::Option::None },
+    };
+
+    let bytes_expr = match &args.source {
+        DeserializeSource::Blob(expr) => quote! { &#expr },
+        DeserializeSource::Path(lit)  => quote! { &::std::fs::read(#lit)? },
+    };
+
+    quote! {
+        let #var_name: #ret_ty =
+            ::toolkit_zero::serialization::open::<#ret_ty>(#bytes_expr, #key_arg)?;
+    }
+    .into()
+}

--- a/toolkit-zero-macros/src/timelock_macro.rs
+++ b/toolkit-zero-macros/src/timelock_macro.rs
@@ -1,0 +1,429 @@
+// ─── #[timelock] ─────────────────────────────────────────────────────────────
+//
+// Attribute macro that replaces a decorated `fn` with an inline
+// `timelock(…)?` / `timelock_async(…).await?` call.
+//
+// Encryption path (params = None):
+//   #[timelock(precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+//   #[timelock(precision = Hour,   format = Hour24, time(14, 0),  salts = s, kdf = k, cadence = DayOfWeek(Tuesday))]
+//   #[timelock(async, precision = Minute, format = Hour24, time(14, 37), salts = s, kdf = k)]
+//
+// Decryption path (params = Some):
+//   #[timelock(params = header)]
+//   #[timelock(async, params = header)]
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    Expr, Ident, ItemFn, LitInt, Token,
+};
+
+// ─── Cadence value ────────────────────────────────────────────────────────────
+
+enum CadenceArg {
+    /// Not supplied (or explicit `None`) → `TimeLockCadence::None`
+    Default,
+    DayOfWeek(Ident),
+    DayOfMonth(LitInt),
+    MonthOfYear(Ident),
+    DayOfWeekInMonth(Ident, Ident),
+    DayOfMonthInMonth(LitInt, Ident),
+    DayOfWeekAndDayOfMonth(Ident, LitInt),
+}
+
+impl CadenceArg {
+    /// Parse after the `=` sign following the `cadence` keyword.
+    fn parse_value(input: ParseStream) -> syn::Result<Self> {
+        let ident: Ident = input.parse()?;
+        match ident.to_string().as_str() {
+            // explicit None → same as omitted
+            "None" => Ok(CadenceArg::Default),
+
+            "DayOfWeek" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let w: Ident = content.parse()?;
+                validate_weekday(&w)?;
+                Ok(CadenceArg::DayOfWeek(w))
+            }
+            "DayOfMonth" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let d: LitInt = content.parse()?;
+                Ok(CadenceArg::DayOfMonth(d))
+            }
+            "MonthOfYear" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let m: Ident = content.parse()?;
+                validate_month(&m)?;
+                Ok(CadenceArg::MonthOfYear(m))
+            }
+            "DayOfWeekInMonth" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let w: Ident = content.parse()?;
+                validate_weekday(&w)?;
+                let _: Token![,] = content.parse()?;
+                let m: Ident = content.parse()?;
+                validate_month(&m)?;
+                Ok(CadenceArg::DayOfWeekInMonth(w, m))
+            }
+            "DayOfMonthInMonth" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let d: LitInt = content.parse()?;
+                let _: Token![,] = content.parse()?;
+                let m: Ident = content.parse()?;
+                validate_month(&m)?;
+                Ok(CadenceArg::DayOfMonthInMonth(d, m))
+            }
+            "DayOfWeekAndDayOfMonth" => {
+                let content;
+                syn::parenthesized!(content in input);
+                let w: Ident = content.parse()?;
+                validate_weekday(&w)?;
+                let _: Token![,] = content.parse()?;
+                let d: LitInt = content.parse()?;
+                Ok(CadenceArg::DayOfWeekAndDayOfMonth(w, d))
+            }
+            other => Err(syn::Error::new(
+                ident.span(),
+                format!(
+                    "#[timelock]: unknown cadence variant `{other}`. \
+                     Expected: None, DayOfWeek, DayOfMonth, MonthOfYear, \
+                     DayOfWeekInMonth, DayOfMonthInMonth, DayOfWeekAndDayOfMonth"
+                ),
+            )),
+        }
+    }
+
+    /// Produce the full `Option::Some(TimeLockCadence::…)` token stream for
+    /// the encryption path.
+    fn to_tokens(&self) -> TokenStream2 {
+        let tl = quote! { ::toolkit_zero::encryption::timelock };
+        match self {
+            CadenceArg::Default => quote! {
+                ::std::option::Option::Some(#tl::TimeLockCadence::None)
+            },
+            CadenceArg::DayOfWeek(w) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::DayOfWeek(#tl::Weekday::#w)
+                )
+            },
+            CadenceArg::DayOfMonth(d) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::DayOfMonth(#d)
+                )
+            },
+            CadenceArg::MonthOfYear(m) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::MonthOfYear(#tl::Month::#m)
+                )
+            },
+            CadenceArg::DayOfWeekInMonth(w, m) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::DayOfWeekInMonth(
+                        #tl::Weekday::#w,
+                        #tl::Month::#m,
+                    )
+                )
+            },
+            CadenceArg::DayOfMonthInMonth(d, m) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::DayOfMonthInMonth(#d, #tl::Month::#m)
+                )
+            },
+            CadenceArg::DayOfWeekAndDayOfMonth(w, d) => quote! {
+                ::std::option::Option::Some(
+                    #tl::TimeLockCadence::DayOfWeekAndDayOfMonth(
+                        #tl::Weekday::#w,
+                        #d,
+                    )
+                )
+            },
+        }
+    }
+}
+
+// ─── Argument struct ──────────────────────────────────────────────────────────
+
+struct TimelockArgs {
+    is_async:  bool,
+    // ── decryption path ──────────────────────────────────────────────────────
+    params:    Option<Expr>,
+    // ── encryption path ──────────────────────────────────────────────────────
+    precision: Option<Ident>,   // Hour | Quarter | Minute
+    format:    Option<Ident>,   // Hour12 | Hour24
+    time_h:    Option<LitInt>,
+    time_m:    Option<LitInt>,
+    cadence:   CadenceArg,      // defaults to None (→ TimeLockCadence::None)
+    salts:     Option<Expr>,
+    kdf:       Option<Expr>,
+}
+
+impl Parse for TimelockArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut is_async  = false;
+        let mut params    = None::<Expr>;
+        let mut precision = None::<Ident>;
+        let mut format    = None::<Ident>;
+        let mut time_h    = None::<LitInt>;
+        let mut time_m    = None::<LitInt>;
+        let mut cadence   = CadenceArg::Default;
+        let mut salts     = None::<Expr>;
+        let mut kdf       = None::<Expr>;
+
+        while !input.is_empty() {
+            // `async` is a keyword in Rust — handle it via Token![async].
+            if input.peek(Token![async]) {
+                let _: Token![async] = input.parse()?;
+                is_async = true;
+            } else if input.peek(Ident) {
+                let ident: Ident = input.parse()?;
+                match ident.to_string().as_str() {
+                    "params" => {
+                        let _: Token![=] = input.parse()?;
+                        params = Some(input.parse()?);
+                    }
+                    "precision" => {
+                        let _: Token![=] = input.parse()?;
+                        precision = Some(input.parse()?);
+                    }
+                    "format" => {
+                        let _: Token![=] = input.parse()?;
+                        format = Some(input.parse()?);
+                    }
+                    "time" => {
+                        let content;
+                        syn::parenthesized!(content in input);
+                        time_h = Some(content.parse()?);
+                        let _: Token![,] = content.parse()?;
+                        time_m = Some(content.parse()?);
+                    }
+                    "cadence" => {
+                        let _: Token![=] = input.parse()?;
+                        cadence = CadenceArg::parse_value(input)?;
+                    }
+                    "salts" => {
+                        let _: Token![=] = input.parse()?;
+                        salts = Some(input.parse()?);
+                    }
+                    "kdf" => {
+                        let _: Token![=] = input.parse()?;
+                        kdf = Some(input.parse()?);
+                    }
+                    other => {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            format!(
+                                "#[timelock]: unknown argument `{other}`. \
+                                 Expected: async, params, precision, format, \
+                                 time, cadence, salts, kdf"
+                            ),
+                        ));
+                    }
+                }
+            }
+
+            // Consume trailing comma.
+            if input.peek(Token![,]) {
+                let _: Token![,] = input.parse()?;
+            }
+        }
+
+        Ok(TimelockArgs { is_async, params, precision, format, time_h, time_m, cadence, salts, kdf })
+    }
+}
+
+// ─── Validators ───────────────────────────────────────────────────────────────
+
+fn validate_weekday(w: &Ident) -> syn::Result<()> {
+    match w.to_string().as_str() {
+        "Monday" | "Tuesday" | "Wednesday" | "Thursday"
+            | "Friday" | "Saturday" | "Sunday" => Ok(()),
+        other => Err(syn::Error::new(
+            w.span(),
+            format!(
+                "#[timelock]: unknown weekday `{other}`. \
+                 Expected: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday"
+            ),
+        )),
+    }
+}
+
+fn validate_month(m: &Ident) -> syn::Result<()> {
+    match m.to_string().as_str() {
+        "January" | "February" | "March"     | "April"
+            | "May"    | "June"     | "July"      | "August"
+            | "September" | "October"  | "November" | "December" => Ok(()),
+        other => Err(syn::Error::new(
+            m.span(),
+            format!(
+                "#[timelock]: unknown month `{other}`. \
+                 Expected: January, February, March, April, May, June, \
+                 July, August, September, October, November, December"
+            ),
+        )),
+    }
+}
+
+// ─── Expansion ───────────────────────────────────────────────────────────────
+
+pub fn expand_timelock(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = match syn::parse::<TimelockArgs>(attr) {
+        Ok(a)  => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let func = match syn::parse::<ItemFn>(item) {
+        Ok(f)  => f,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let binding = &func.sig.ident;
+    let tl = quote! { ::toolkit_zero::encryption::timelock };
+
+    let call = if let Some(params_expr) = &args.params {
+        // ── Decryption path ──────────────────────────────────────────────────
+        // `params` is mutually exclusive with all encryption path arguments.
+        if args.precision.is_some()
+            || args.format.is_some()
+            || args.time_h.is_some()
+            || args.salts.is_some()
+            || args.kdf.is_some()
+        {
+            return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `params` is mutually exclusive with \
+                 precision, format, time, salts, and kdf",
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        if args.is_async {
+            quote! {
+                let #binding = #tl::timelock_async(
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::Some(#params_expr),
+                ).await?;
+            }
+        } else {
+            quote! {
+                let #binding = #tl::timelock(
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::None,
+                    ::std::option::Option::Some(#params_expr),
+                )?;
+            }
+        }
+    } else {
+        // ── Encryption path ──────────────────────────────────────────────────
+        let precision = match &args.precision {
+            Some(p) => p,
+            None => return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `precision = Hour|Quarter|Minute` is required",
+            ).to_compile_error().into(),
+        };
+
+        let fmt = match &args.format {
+            Some(f) => f,
+            None => return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `format = Hour12|Hour24` is required",
+            ).to_compile_error().into(),
+        };
+
+        let time_h = match &args.time_h {
+            Some(h) => h,
+            None => return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `time(hour, minute)` is required",
+            ).to_compile_error().into(),
+        };
+        let time_m = args.time_m.as_ref().unwrap(); // always set with time_h
+
+        let salts = match &args.salts {
+            Some(s) => s,
+            None => return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `salts = <TimeLockSalts expr>` is required",
+            ).to_compile_error().into(),
+        };
+
+        let kdf = match &args.kdf {
+            Some(k) => k,
+            None => return syn::Error::new_spanned(
+                &func.sig.ident,
+                "#[timelock]: `kdf = <KdfParams expr>` is required",
+            ).to_compile_error().into(),
+        };
+
+        // Validate precision ident.
+        match precision.to_string().as_str() {
+            "Hour" | "Quarter" | "Minute" => {}
+            _ => return syn::Error::new_spanned(
+                precision,
+                "#[timelock]: `precision` must be Hour, Quarter, or Minute",
+            ).to_compile_error().into(),
+        }
+
+        // Validate format ident.
+        match fmt.to_string().as_str() {
+            "Hour12" | "Hour24" => {}
+            _ => return syn::Error::new_spanned(
+                fmt,
+                "#[timelock]: `format` must be Hour12 or Hour24",
+            ).to_compile_error().into(),
+        }
+
+        let cadence_tokens = args.cadence.to_tokens();
+
+        if args.is_async {
+            quote! {
+                let #binding = #tl::timelock_async(
+                    #cadence_tokens,
+                    ::std::option::Option::Some(
+                        #tl::TimeLockTime::new(#time_h, #time_m)
+                            .expect("#[timelock]: time() values out of range — hour must be 0–23, minute 0–59")
+                    ),
+                    ::std::option::Option::Some(#tl::TimePrecision::#precision),
+                    ::std::option::Option::Some(#tl::TimeFormat::#fmt),
+                    ::std::option::Option::Some(#salts),
+                    ::std::option::Option::Some(#kdf),
+                    ::std::option::Option::None,
+                ).await?;
+            }
+        } else {
+            quote! {
+                let #binding = #tl::timelock(
+                    #cadence_tokens,
+                    ::std::option::Option::Some(
+                        #tl::TimeLockTime::new(#time_h, #time_m)
+                            .expect("#[timelock]: time() values out of range — hour must be 0–23, minute 0–59")
+                    ),
+                    ::std::option::Option::Some(#tl::TimePrecision::#precision),
+                    ::std::option::Option::Some(#tl::TimeFormat::#fmt),
+                    ::std::option::Option::Some(#salts),
+                    ::std::option::Option::Some(#kdf),
+                    ::std::option::Option::None,
+                )?;
+            }
+        }
+    };
+
+    call.into()
+}


### PR DESCRIPTION
…print, bump versions

closes #23 